### PR TITLE
Topology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 # include $(shell ocamlfind query visitors)/Makefile.preprocess
 
-.PHONY: test test-promote clean
-
-
+.PHONY: test promote test-promote clean
 
 default:
 	dune build src/bin/main.exe
@@ -23,6 +21,9 @@ generatedVisitors: src/lib/frontend/Syntax.processed.ml
 # 	cp _build/default/test/testing.exe test
 test: default
 	python3 ./test/runtests.py
+
+promote:
+	cp test/output/* test/expected/
 
 test-promote: default
 	python3 ./test/runtests.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # include $(shell ocamlfind query visitors)/Makefile.preprocess
 
-.PHONY: test clean
+.PHONY: test test-promote clean
 
 
 
@@ -23,6 +23,10 @@ generatedVisitors: src/lib/frontend/Syntax.processed.ml
 # 	cp _build/default/test/testing.exe test
 test: default
 	python3 ./test/runtests.py
+
+test-promote: default
+	python3 ./test/runtests.py
+	cp test/output/* test/expected/
 
 doc:
 	dune build @doc

--- a/examples/interp_tests/basics.json
+++ b/examples/interp_tests/basics.json
@@ -1,5 +1,6 @@
 {
   "switches": 3,
+  "links": "full mesh",
   "max time": 9999999,
   "default input gap": 10000,
   "random seed": 0,

--- a/examples/interp_tests/basics.json
+++ b/examples/interp_tests/basics.json
@@ -4,6 +4,7 @@
   "max time": 9999999,
   "default input gap": 10000,
   "random seed": 0,
+  "recirculation_ports": [255, 196, 3],
   "events": [
     {"name":"packetin", "args": [10, 100]},
     {"name":"packetin", "args": [11, 101], "locations": ["0:0"]},

--- a/examples/interp_tests/basics.json
+++ b/examples/interp_tests/basics.json
@@ -6,9 +6,9 @@
   "random seed": 0,
   "events": [
     {"name":"packetin", "args": [10, 100]},
-    {"name":"packetin", "args": [11, 101], "locations": [0]},
-    {"name":"packetin", "args": [12, 102], "locations": [0, 1, 2]},
+    {"name":"packetin", "args": [11, 101], "locations": ["0:0"]},
+    {"name":"packetin", "args": [12, 102], "locations": ["0:0", "1:7", "2:1"]},
     {"name":"packetin", "args": [13, 103], "timestamp": 40000},
-    {"name":"packetin", "args": [14, 104], "timestamp": 40007, "locations": [0, 1]}
+    {"name":"packetin", "args": [14, 104], "timestamp": 40007, "locations": ["0:3", "1:19"]}
   ]
 }

--- a/examples/interp_tests/bouncing.dpt
+++ b/examples/interp_tests/bouncing.dpt
@@ -1,0 +1,76 @@
+/*
+Basic DPT primitives: events, handlers, and local variables
+*/
+/* jsonch 10/15/20 */
+
+/* an event is a data record.
+An event declaration defines the record type and fields. */
+event count_to_10 (int count);
+
+/* Each event has a handler that executes when a new event
+of that type arrives.*/
+/* Print the first 10 integers. */
+handle count_to_10 (int count) {
+	/* Inside of an event handler, local variables can be
+	declared and used in typical ways. */
+	/* Note that the only global variables are constants. */
+	/* integers have a polymorphic argument: their width in bits.
+	If the argument is omitted, the default is 32 bits. */
+	/*	integers are currently unsigned. */
+	int<<32>> next_count = count + 1;
+	if (count > 10){
+		/* Print functions are for debugging.
+		   Currently, only integer printing
+		   is implemented in the backend (10/15/20) */
+		printf("got to 10");
+	}
+	else {
+		if (count == 0){
+			printf("at 0");
+		}
+		else {
+			printf("%d", count);
+		}
+		/* For testing our port variables: send to another switch in the network
+		   after the second time processing it.
+		*/
+		if (ingress_port == recirculation_port) {
+			int next_loc = self;
+			if (next_loc == 2) {
+				next_loc = 0;
+			} else {
+				next_loc = next_loc + 1;
+			}
+			generate_switch (next_loc, count_to_10(next_count));
+		} else {
+			generate count_to_10(next_count);
+		}
+	}
+}
+
+/*
+packetin and continue are special builtin events that let
+a DPT program interface with an underlying P4 program.
+-- packetin is an event that a P4 program can generate
+from a single point in its control flow. From the P4 program's
+point of view, the event handler gets executed immediately,
+just like a function call would. There are no queues or recirculation
+for packetin events.
+-- continue is an event that allows a DPT handler to emit a packet
+back to P4, from the exact point in the P4 code where packetin is called.
+The arguments of a continue event are the same as the arguments to a
+packetin event. Like packetin events, there are no queues or packet
+recirculations for continue events.
+
+Down the line, we want to generalize this so that the P4 program
+can call other types of events as well (for example, a packetin event
+that is specific to a TCP packet and has extra arguments)
+*/
+
+entry event packetin (int src, int dst);
+exit event continue (int src, int dst);
+
+handle packetin (int src, int dst){
+	generate count_to_10 (0); // Dangerous, because this happens at linerate
+	generate continue (src, dst);
+}

--- a/examples/interp_tests/bouncing.json
+++ b/examples/interp_tests/bouncing.json
@@ -1,0 +1,15 @@
+{
+  "switches": 3,
+  "links": "full mesh",
+  "max time": 9999999,
+  "default input gap": 10000,
+  "random seed": 0,
+  "recirculation_ports": [255, 196, 3],
+  "events": [
+    {"name":"packetin", "args": [10, 100]},
+    {"name":"packetin", "args": [11, 101], "locations": ["0:0"]},
+    {"name":"packetin", "args": [12, 102], "locations": ["0:0", "1:7", "2:1"]},
+    {"name":"packetin", "args": [13, 103], "timestamp": 40000},
+    {"name":"packetin", "args": [14, 104], "timestamp": 40007, "locations": ["0:3", "1:19"]}
+  ]
+}

--- a/examples/interp_tests/chain_stateful_firewall.dpt
+++ b/examples/interp_tests/chain_stateful_firewall.dpt
@@ -28,7 +28,7 @@ handle update_last_seen(int idx, int time) {
   event this = update_last_seen(idx, time);
   Array.set(last_seen, idx, time);
   if (self != tail) {
-    generate Event.sslocate(this, succ);
+    generate_switch (succ, this);
   }
 }
 
@@ -44,7 +44,7 @@ handle packetin(int src, int dst, int port) {
     // Only update if we're nearing the timeout to avoid many many writes
     if ((now - last_seen_time) > (TIME_THRESH - 500000)) {
       event updater = update_last_seen(idx, now);
-      generate Event.sslocate(updater, head);
+      generate_switch (head, updater);
     }
 
     generate continue(dst);

--- a/examples/interp_tests/chain_stateful_firewall.json
+++ b/examples/interp_tests/chain_stateful_firewall.json
@@ -14,9 +14,9 @@
   },
   "events": [
     {"name":"packetin", "args": [10, 100, 0], "timestamp": 11000000},
-    {"name":"packetin", "args": [11, 101, 0], "locations": [1]},
-    {"name":"packetin", "args": [13, 103, 1], "locations": [0, 1, 2]},
-    {"name":"packetin", "args": [101, 11, 1], "locations": [0, 1, 2]},
-    {"name":"packetin", "args": [100, 10, 1], "locations": [0, 1, 2]}
+    {"name":"packetin", "args": [11, 101, 0], "locations": ["1:1"]},
+    {"name":"packetin", "args": [13, 103, 1], "locations": ["0:0", "1:1", "2:0"]},
+    {"name":"packetin", "args": [101, 11, 1], "locations": ["0:0", "1:1", "2:0"]},
+    {"name":"packetin", "args": [100, 10, 1], "locations": ["0:0", "1:1", "2:0"]}
   ]
 }

--- a/examples/interp_tests/chain_stateful_firewall.json
+++ b/examples/interp_tests/chain_stateful_firewall.json
@@ -1,5 +1,9 @@
 {
   "switches": 3,
+  "links": {
+    "0:1" : "1:0",
+    "1:2" : "2:1"
+  },
   "max time": 900000000,
   "default input gap": 100000,
   "random seed": 0,

--- a/examples/interp_tests/mac_learner.dpt
+++ b/examples/interp_tests/mac_learner.dpt
@@ -1,0 +1,24 @@
+global Array.t<<1>> learned_macs_1 = Array.create(4); // True if we've learnd this mac address
+global Array.t<<1>> learned_macs_2 = Array.create(4); // Second copy so we can access it twice
+global Array.t<<8>> mac_table = Array.create(4); // 2-bit mac addresses, 8-bit ports
+
+event learn_mac(int<<2>> mac, int<<8>> out_port) {
+  Array.set(learned_macs_1, mac, 1);
+  Array.set(learned_macs_2, mac, 1);
+  Array.set(mac_table, mac, out_port);
+}
+
+event eth(int<<2>> src_mac, int<<2>> dst_mac) {
+  // Learn src_mac if necessary
+  if (Array.get(learned_macs_1, src_mac) == 0) {
+    generate learn_mac(src_mac, (int<<8>>)ingress_port);
+  }
+
+  // Handle packet forwarding
+  if (Array.get(learned_macs_2, dst_mac) == 1) {
+    int<<8>> port = Array.get(mac_table, dst_mac);
+    generate_port (port, this);
+  } else { // Flood the packet
+    generate_ports (flood ingress_port, this);
+  }
+}

--- a/examples/interp_tests/mac_learner.json
+++ b/examples/interp_tests/mac_learner.json
@@ -1,0 +1,18 @@
+{
+  "switches": 5,
+  "links": {
+    "0:1" : "1:0",
+    "2:1" : "1:2",
+    "2:3" : "3:2",
+    "2:4" : "4:2"
+  },
+  "max time": 9999999,
+  "default input gap": 10000,
+  "random seed": 0,
+  "events": [
+    {"name":"eth", "args": [0, 1], "locations":["0:7"]},
+    {"name":"eth", "args": [1, 0], "locations":["3:9"]},
+    {"name":"eth", "args": [2, 1], "locations":["4:42"]},
+    {"name":"eth", "args": [0, 2], "locations":["0:7"]}
+  ]
+}

--- a/examples/popl22/chain_prob_stateful_firewall.dpt
+++ b/examples/popl22/chain_prob_stateful_firewall.dpt
@@ -48,8 +48,7 @@ exit event response_continue (int src_ip, int dst_ip);
 event add_to_firewall(int[2] args) {
   BloomFilter.add_to_filter(filter, args);
   if (self != tail) {
-    // generate Event.sslocate(this, succ);
-    generate Event.sslocate(add_to_firewall(args), succ);
+    generate_switch (succ, add_to_firewall(args));
   }
 }
 
@@ -57,7 +56,7 @@ handle request_packet(int client_ip, int server_ip) {
   bool in_filter = BloomFilter.in_filter(filter, [client_ip; server_ip]);
   if (in_filter == false) {
     // event add = add_to_firewall([client_ip; server_ip]);
-    generate Event.sslocate(add_to_firewall([client_ip; server_ip]), head);
+    generate_switch (head, add_to_firewall([client_ip; server_ip]));
   }
   generate request_continue(client_ip, server_ip);
 }

--- a/examples/popl22/chain_prob_stateful_firewall_timeout.dpt
+++ b/examples/popl22/chain_prob_stateful_firewall_timeout.dpt
@@ -34,14 +34,14 @@ exit event response_continue (int src_ip, int dst_ip);
 event add_to_firewall(int[2] args) {
   BloomFilterTimeout.add_to_filter(filter, args);
   if (self != tail) {
-    generate Event.sslocate(add_to_firewall(args), succ);
+    generate_switch (succ, add_to_firewall(args));
   }
 }
 
 handle request_packet(int client_ip, int server_ip) {
   bool in_filter = BloomFilterTimeout.in_filter(filter, [client_ip; server_ip]);
   if (in_filter == false) {
-    generate Event.sslocate(add_to_firewall([client_ip; server_ip]), head);
+    generate_switch (head, add_to_firewall([client_ip; server_ip]));
   }
   generate request_continue(client_ip, server_ip);
 }

--- a/examples/popl22/chain_replication.dpt
+++ b/examples/popl22/chain_replication.dpt
@@ -70,9 +70,9 @@ handle write(int idx, int seq, int data) {
       Array.set(registers, idx, data);
       // Either propagate to next in chain, or tell head we're done
       if (self != tail) {
-        generate Event.sslocate(write(idx, seq, data), succ);
+        generate_switch (succ, write(idx, seq, data));
       } else {
-        generate Event.sslocate(ack(idx), head);
+        generate_switch (head, ack(idx));
       }
     }
   }
@@ -82,7 +82,7 @@ handle write(int idx, int seq, int data) {
 handle ack(int idx) {
   Array.set(pending, idx, FALSE);
   if (self != tail) {
-    generate Event.sslocate(ack(idx), succ);
+    generate_switch (succ, ack(idx));
   }
 }
 
@@ -111,7 +111,7 @@ handle pktin(int src, int dst) {
   bool ntw = need_to_write(src, dst); // Can't manually inline this or function inlining fails
   if (ntw) {
     // event writer = write(0,0,0); // Specific values are application-specific
-    generate Event.sslocate(write(0,0,0), head);
+    generate_switch (head, write(0,0,0));
   }
 
   // Actually do the processing
@@ -120,7 +120,7 @@ handle pktin(int src, int dst) {
   if (r == TRUE) {
     // If we're in the middle of a write, send it to the tail, since that has
     // the last fully consistent data
-    generate Event.sslocate(process(src, dst, idx), tail);
+    generate_switch (tail, process(src, dst, idx));
   } else {
     process_fun(src, dst, idx);
   }

--- a/examples/popl22/countmin_historical.dpt
+++ b/examples/popl22/countmin_historical.dpt
@@ -30,5 +30,5 @@ handle pktin(int src, int dst) {
 
 handle query(int src, int dst, int response_loc) {
   auto val = CMSTimeout.query(sketch, [src; dst]);
-  generate Event.sslocate(query_response(src, dst, val), response_loc);
+  generate_switch (response_loc, query_response(src, dst, val));
 }

--- a/examples/popl22/rerouter.dpt
+++ b/examples/popl22/rerouter.dpt
@@ -189,7 +189,7 @@ handle update_route(int i) {
     // If the path length is infinite,
     // query all neighbors for a route to i.
     if (pathlen == INF) {
-        generate_multi (NEIGHBORS, query_nexthop(SELF, i));
+        generate_ports (NEIGHBORS, query_nexthop(SELF, i));
     }
     else {
         // If the pathlength is not zero (i.e., this is not
@@ -200,7 +200,7 @@ handle update_route(int i) {
             int next_hop = Array.get(nexthop_nid, i);
             int nexthop_is_down = Array.getm(last_seen, next_hop, nid_is_down, ts);
             if (nexthop_is_down == TRUE) {
-                generate_multi (NEIGHBORS, query_nexthop(SELF, i));
+                generate_ports (NEIGHBORS, query_nexthop(SELF, i));
             }
         }
     }
@@ -224,7 +224,7 @@ handle reply_probe (int nid) {
 }
 
 handle check_neighbors() {
-    generate_multi (NEIGHBORS, query_probe(SELF));
+    generate_ports (NEIGHBORS, query_probe(SELF));
     generate Event.delay(check_neighbors(), t_wait);
 }
 

--- a/examples/popl22/rerouter.dpt
+++ b/examples/popl22/rerouter.dpt
@@ -38,8 +38,6 @@ const int t_wait = 10000;
 // Location identifiers
 // Set by macro preprocessor.
 const int SELF = 0;
-group NEIGHBORS = {1};
-
 // state
 // map dst --> (shortest known pathlen, next hop)
 global Array.t<<32>> nexthop_pathlen  = Array.create(tbl_sz);
@@ -189,7 +187,7 @@ handle update_route(int i) {
     // If the path length is infinite,
     // query all neighbors for a route to i.
     if (pathlen == INF) {
-        generate_ports (NEIGHBORS, query_nexthop(SELF, i));
+        generate_ports ({1}, query_nexthop(SELF, i));
     }
     else {
         // If the pathlength is not zero (i.e., this is not
@@ -200,7 +198,7 @@ handle update_route(int i) {
             int next_hop = Array.get(nexthop_nid, i);
             int nexthop_is_down = Array.getm(last_seen, next_hop, nid_is_down, ts);
             if (nexthop_is_down == TRUE) {
-                generate_ports (NEIGHBORS, query_nexthop(SELF, i));
+                generate_ports ({1}, query_nexthop(SELF, i));
             }
         }
     }
@@ -224,7 +222,7 @@ handle reply_probe (int nid) {
 }
 
 handle check_neighbors() {
-    generate_ports (NEIGHBORS, query_probe(SELF));
+    generate_ports ({1}, query_probe(SELF));
     generate Event.delay(check_neighbors(), t_wait);
 }
 

--- a/examples/popl22/rerouter.dpt
+++ b/examples/popl22/rerouter.dpt
@@ -163,7 +163,7 @@ handle packetin(int dst) {
 // lookup pathlen to dst, send message back to q_nid
 handle query_nexthop(int q_nid, int dst) {
     int pathlen = Array.get(nexthop_pathlen, dst);
-    generate Event.sslocate(reply_nexthop(SELF, dst, pathlen), q_nid);
+    generate_switch (q_nid, reply_nexthop(SELF, dst, pathlen));
 }
 
 // update the routing table if the path is shorter.
@@ -189,7 +189,7 @@ handle update_route(int i) {
     // If the path length is infinite,
     // query all neighbors for a route to i.
     if (pathlen == INF) {
-        mgenerate Event.smlocate(query_nexthop(SELF, i), NEIGHBORS);
+        generate_multi (NEIGHBORS, query_nexthop(SELF, i));
     }
     else {
         // If the pathlength is not zero (i.e., this is not
@@ -200,7 +200,7 @@ handle update_route(int i) {
             int next_hop = Array.get(nexthop_nid, i);
             int nexthop_is_down = Array.getm(last_seen, next_hop, nid_is_down, ts);
             if (nexthop_is_down == TRUE) {
-                mgenerate Event.smlocate(query_nexthop(SELF, i), NEIGHBORS);
+                generate_multi (NEIGHBORS, query_nexthop(SELF, i));
             }
         }
     }
@@ -215,7 +215,7 @@ handle update_route(int i) {
 // ---- fault detection ----
 // Just reply to src_nid.
 handle query_probe(int src_nid) {
-    generate Event.sslocate(reply_probe(SELF), src_nid);
+    generate_switch (src_nid, reply_probe(SELF));
 }
 // update the last_seen table.
 handle reply_probe (int nid) {
@@ -224,7 +224,7 @@ handle reply_probe (int nid) {
 }
 
 handle check_neighbors() {
-    mgenerate Event.smlocate(query_probe(SELF), NEIGHBORS);
+    generate_multi (NEIGHBORS, query_probe(SELF));
     generate Event.delay(check_neighbors(), t_wait);
 }
 

--- a/examples/popl22/starflow.dpt
+++ b/examples/popl22/starflow.dpt
@@ -111,18 +111,18 @@ handle monitor_pkt(int src, int len) {
   if (mtch == MMATCH) {
     if (idx == 0) {
       if (blk_id == 0) {
-        generate Event.sslocate(short_record(src, len, [stored_recs[0]; stored_recs[1]]), COLLECTION_SERVER);
+        generate_switch (COLLECTION_SERVER, short_record(src, len, [stored_recs[0]; stored_recs[1]]));
       } else {
-        generate Event.sslocate(long_record(src, len, stored_recs), COLLECTION_SERVER);
+        generate_switch (COLLECTION_SERVER, long_record(src, len, stored_recs));
       }
     }
   } else {
     // if there wasn't a match, we need to generate a new record no matter what.
     // Note: at this point, we could zero out the invalid entries too. Original starflow implementation assumes the server takes care of it.
     if (blk_id == 0) {
-      generate Event.sslocate(short_record(src, len, [stored_recs[0]; stored_recs[1]]), COLLECTION_SERVER);
+      generate_switch (COLLECTION_SERVER, short_record(src, len, [stored_recs[0]; stored_recs[1]]));
     } else {
-      generate Event.sslocate(long_record(src, len, stored_recs), COLLECTION_SERVER);
+      generate_switch (COLLECTION_SERVER, long_record(src, len, stored_recs));
       // in this case, we also have to free the long block for another flow -- do that with a control event.
       generate free_block(blk_id);
     }

--- a/examples/regression/multicastvector.dpt
+++ b/examples/regression/multicastvector.dpt
@@ -55,16 +55,11 @@ group group1 = {0, 1, 3};
 event foo() {
   // To generate a singlecast event, you just do things normally, e.g.
   event f = foo();
-  f = Event.sslocate(f, 1); // Send to switch 1
   f = Event.delay(f, 100); // Delay by 100 ns
-  generate f; // Sends f off to appear at switch 1 in 100ns.
+  generate_switch (1, f); // Sends f off to appear at switch 1 in 100ns.
 
   // To generate a multicast event, you start the same way...
   event f = foo();
-  // But when you send it to a group, the type changes to "mevent" (multicast event)
-  // To do this, you use different combinators. Event.smlocate takes a singlecast event and a group,
-  // and generates a multicast event.
-  mevent m = Event.smlocate(f, group1); // Turns f into a mevent sent to group 1.
-  m = Event.mdelay(m, 100); // Different version of the delay function for multicast events
-  mgenerate m; // Different generate keyword as well. This will cause m to appear at switches 0, 1, 3 in 100ns.
+  event m = Event.delay(f, 100);
+  generate_multi (group1, m); // Different generate keyword. This will cause m to appear at switches 0, 1, 3 in 100ns.
 }

--- a/examples/regression/multicastvector.dpt
+++ b/examples/regression/multicastvector.dpt
@@ -61,5 +61,5 @@ event foo() {
   // To generate a multicast event, you start the same way...
   event f = foo();
   event m = Event.delay(f, 100);
-  generate_multi (group1, m); // Different generate keyword. This will cause m to appear at switches 0, 1, 3 in 100ns.
+  generate_ports (group1, m); // Different generate keyword. This will cause m to appear at switches 0, 1, 3 in 100ns.
 }

--- a/examples/regression/multicastvector.dpt
+++ b/examples/regression/multicastvector.dpt
@@ -50,7 +50,7 @@ fun int get_connected_port(int src, int output_port) {
 
 // Defines a multicast group named group1.
 // Packets sent to this group arrive at switches 0, 1 and 3, and not 2 or 4.
-group group1 = {0, 1, 3};
+const group group1 = {0, 1, 3};
 
 event foo() {
   // To generate a singlecast event, you just do things normally, e.g.

--- a/src/lib/backend/LLTranslate/LLOp.ml
+++ b/src/lib/backend/LLTranslate/LLOp.ml
@@ -249,7 +249,7 @@ module TofinoAlu = struct
       | ECall (fcn_id, args) ->
         (* a call could either be a call, or an event declaration. *)
         (match raw_ty_of_exp val_exp with
-        | TEvent _ ->
+        | TEvent ->
           let call_result =
             ctx_call_codegen
               LLConstants.event_generate_cid
@@ -323,7 +323,7 @@ module TofinoAlu = struct
     ; GS.int_assign_instr (Cid.concat ev_struct_id event_loc_field) 0
     ; GS.int_assign_instr (Cid.concat ev_struct_id event_delay_field) 0 ]
     @
-    (* background events are carried in headers that need to be set to valid. 
+    (* background events are carried in headers that need to be set to valid.
          Background events must also be sure to set up the footer. *)
     match evrec.event_sort with
     | EBackground ->

--- a/src/lib/backend/LLTranslate/LLOp.ml
+++ b/src/lib/backend/LLTranslate/LLOp.ml
@@ -281,6 +281,8 @@ module TofinoAlu = struct
         (* let poly = Integer.to_int (zint_from_evalue (CL.hd exps)) in  *)
         let args = CL.map (oper_from_immediate hdl_id) (CL.tl exps) in
         alu_name, IS.new_hasher alu_name width poly outvar_mid args
+      | EFlood _ -> 
+        error "[from_assign] flood not yet supported by backend."        
     in
     !dprint_endline
       (sprintf "[from_assign] created alu: " ^ Printing.cid_to_string alu_name);

--- a/src/lib/backend/LLTranslate/LLTranslate.ml
+++ b/src/lib/backend/LLTranslate/LLTranslate.ml
@@ -506,7 +506,9 @@ let from_dpt (ds : decls) (opgraph_recs : prog_opgraph) : IS.llProg =
   (* generate backend defs for register arrays *)
   let regarray_defs = CL.map regdec_from_decl ds |> CL.flatten in
   (* generate constants for groups *)
-  let group_defs = CL.filter_map groupdec_from_decl ds in
+  (* no more groups! *)
+  (* let group_defs = CL.filter_map groupdec_from_decl ds in *)
+
   (* translate operation statements into backend compute objects,
        use the opgraphs to set control flow between objects. *)
   let backend_handler_defs = CL.map dpahandler_from_handler opgraph_recs in
@@ -521,7 +523,7 @@ let from_dpt (ds : decls) (opgraph_recs : prog_opgraph) : IS.llProg =
     { tofino_prog with
       instr_dict =
         tofino_prog.instr_dict
-        @ IS.dict_of_decls group_defs
+        (* @ IS.dict_of_decls group_defs *)
         @ IS.dict_of_decls regarray_defs
         @ IS.dict_of_decls event_decls
         @ IS.dict_of_decls dpt_struct_defs

--- a/src/lib/backend/LLTranslate/LLTranslate.ml
+++ b/src/lib/backend/LLTranslate/LLTranslate.ml
@@ -364,13 +364,17 @@ let regdec_from_decl dec =
 let cur_group_iid = ref 0
 
 let groupdec_from_decl dec =
-  match dec.d with
+  ignore dec;
+  (* match dec.d with
   | DGroup (group_id, _) ->
     let width = LLConstants.event_loc_width in
     cur_group_iid := !cur_group_iid + 1;
     let giid = !cur_group_iid in
     Some (IS.new_private_constdef (Cid.Id group_id) width giid)
-  | _ -> None
+  | _ -> None *)
+  failwith
+    "Group declarations don't exist anymore, gonna have to get these by \
+     walking through the program"
 ;;
 
 (* generate the bitvector metadata that indicate which

--- a/src/lib/frontend/Lexer.mll
+++ b/src/lib/frontend/Lexer.mll
@@ -43,7 +43,7 @@ rule token = parse
   | "bool"            { TBOOL (position lexbuf) }
   | "event"           { EVENT (position lexbuf) }
   | "generate"        { GENERATE (position lexbuf) }
-  | "generate_single" { SGENERATE (position lexbuf) }
+  | "generate_switch" { SGENERATE (position lexbuf) }
   | "generate_multi"  { MGENERATE (position lexbuf) }
   | "generate_port"   { PGENERATE (position lexbuf) }
   | "printf"          { PRINTF (position lexbuf) }

--- a/src/lib/frontend/Lexer.mll
+++ b/src/lib/frontend/Lexer.mll
@@ -45,6 +45,7 @@ rule token = parse
   | "mevent"          { MEVENT (position lexbuf) }
   | "generate"        { GENERATE (position lexbuf) }
   | "mgenerate"       { MGENERATE (position lexbuf) }
+  | "generate_port"   { PGENERATE (position lexbuf) }
   | "printf"          { PRINTF (position lexbuf) }
   | "handle"	        { HANDLE (position lexbuf) }
   | "fun"             { FUN (position lexbuf)}

--- a/src/lib/frontend/Lexer.mll
+++ b/src/lib/frontend/Lexer.mll
@@ -44,7 +44,7 @@ rule token = parse
   | "event"           { EVENT (position lexbuf) }
   | "generate"        { GENERATE (position lexbuf) }
   | "generate_switch" { SGENERATE (position lexbuf) }
-  | "generate_multi"  { MGENERATE (position lexbuf) }
+  | "generate_ports"  { MGENERATE (position lexbuf) }
   | "generate_port"   { PGENERATE (position lexbuf) }
   | "printf"          { PRINTF (position lexbuf) }
   | "handle"	        { HANDLE (position lexbuf) }
@@ -71,6 +71,7 @@ rule token = parse
   | "for"             { FOR (position lexbuf) }
   | "size_to_int"     { SIZECAST (position lexbuf) }
   | "symbolic"        { SYMBOLIC (position lexbuf) }
+  | "flood"           { FLOOD (position lexbuf) }
   | id as s           { ID (position lexbuf, Id.create s) }
   | "'"(id as s)      { QID (position lexbuf, Id.create s) }
   | num as n          { NUM (position lexbuf, Z.of_string n) }

--- a/src/lib/frontend/Lexer.mll
+++ b/src/lib/frontend/Lexer.mll
@@ -42,9 +42,9 @@ rule token = parse
   | "int"             { TINT (position lexbuf) }
   | "bool"            { TBOOL (position lexbuf) }
   | "event"           { EVENT (position lexbuf) }
-  | "mevent"          { MEVENT (position lexbuf) }
   | "generate"        { GENERATE (position lexbuf) }
-  | "mgenerate"       { MGENERATE (position lexbuf) }
+  | "generate_single" { SGENERATE (position lexbuf) }
+  | "generate_multi"  { MGENERATE (position lexbuf) }
   | "generate_port"   { PGENERATE (position lexbuf) }
   | "printf"          { PRINTF (position lexbuf) }
   | "handle"	        { HANDLE (position lexbuf) }

--- a/src/lib/frontend/Linerate.ml
+++ b/src/lib/frontend/Linerate.ml
@@ -65,7 +65,7 @@ let check prog =
             let orig_env = env in
             self#visit_body dummy body;
             env <- orig_env)
-        | DConst (x, { raw_ty = TEvent _; _ }, exp) ->
+        | DConst (x, { raw_ty = TEvent; _ }, exp) ->
           if is_exit env exp
           then env <- { env with exit_vars = VarSet.add x env.exit_vars }
           else ()

--- a/src/lib/frontend/Linerate.ml
+++ b/src/lib/frontend/Linerate.ml
@@ -119,10 +119,11 @@ let check prog =
         then ()
         else if env.in_if
         then
-          Console.warning_position
+          ()
+          (* Console.warning_position
             e.espan
             "Conditional generation of potential non-exit event in entry \
-             handler."
+             handler." *)
         else
           Console.warning_position
             e.espan

--- a/src/lib/frontend/Parser.mly
+++ b/src/lib/frontend/Parser.mly
@@ -70,8 +70,8 @@
 %token <Span.t> DOT
 %token <Span.t> TBOOL
 %token <Span.t> EVENT
-%token <Span.t> MEVENT
 %token <Span.t> GENERATE
+%token <Span.t> SGENERATE
 %token <Span.t> MGENERATE
 %token <Span.t> PGENERATE
 %token <Span.t> TINT
@@ -136,8 +136,7 @@ ty:
     | AUTO                              { ty_sp (TQVar (QVar (fresh_auto ()))) $1 }
     | cid    				                    { ty_sp (TName (snd $1, [], true)) (fst $1) }
     | cid poly				                  { ty_sp (TName (snd $1, snd $2, true)) (fst $1) }
-    | EVENT                             { ty_sp (TEvent false) $1}
-    | MEVENT                            { ty_sp (TEvent true) $1}
+    | EVENT                             { ty_sp TEvent $1}
     | VOID                              { ty_sp (TVoid) $1 }
     | GROUP                             { ty_sp (TGroup) $1 }
     | MEMOP poly                        { ty_sp (mk_tmemop (fst $2) (snd $2)) (Span.extend $1 (fst $2))}
@@ -370,9 +369,10 @@ statement1:
     | ID ASSIGN exp SEMI	                  { sassign_sp (snd $1) $3 (Span.extend (fst $1) $4) }
     | RETURN SEMI                           { sret_sp None (Span.extend $1 $2) }
     | RETURN exp SEMI                       { sret_sp (Some $2) (Span.extend $1 $3) }
-    | GENERATE exp SEMI                     { gen_sp GSingle $2 (Span.extend $1 $3)}
-    | MGENERATE exp SEMI                    { gen_sp GMulti $2 (Span.extend $1 $3)}
-    | PGENERATE LPAREN exp COMMA exp RPAREN SEMI { gen_sp (GPort $5) $3 (Span.extend $1 $7)}
+    | GENERATE exp SEMI                     { gen_sp (GSingle None) $2 (Span.extend $1 $3)}
+    | SGENERATE LPAREN exp COMMA exp RPAREN SEMI { gen_sp (GSingle (Some $3)) $5 (Span.extend $1 $7)}
+    | MGENERATE LPAREN exp COMMA exp RPAREN SEMI { gen_sp (GMulti $3) $5 (Span.extend $1 $7)}
+    | PGENERATE LPAREN exp COMMA exp RPAREN SEMI { gen_sp (GPort $3) $5 (Span.extend $1 $7)}
     | cid paren_args SEMI                   { scall_sp (snd $1) (snd $2) (Span.extend (fst $1) $3) }
     | MATCH args WITH branches              { match_sp $2 (snd $4) (Span.extend $1 (fst $4)) }
     | MATCH LPAREN multiargs RPAREN WITH branches  { match_sp $3 (snd $6) (Span.extend $1 (fst $6)) }

--- a/src/lib/frontend/Parser.mly
+++ b/src/lib/frontend/Parser.mly
@@ -213,7 +213,8 @@ exp:
     | LBRACKET exps RBRACKET              { vector_sp $2 (Span.extend $1 $3) }
     | SIZECAST LPAREN size RPAREN             { szcast_sp (IConst 32) (snd $3) (Span.extend $1 $4) }
     | SIZECAST single_poly LPAREN size RPAREN { szcast_sp (snd $2) (snd $4) (Span.extend $1 $5) }
-    | FLOOD exp { flood_sp $2 (Span.extend $1 $2.espan) }
+    | FLOOD exp                           { flood_sp $2 (Span.extend $1 $2.espan) }
+    | LBRACE args RBRACE                  { group_sp $2 (Span.extend $1 $3) }
 
 exps:
   | exp                                 { [$1] }
@@ -303,7 +304,6 @@ decl:
                                             { [memop_sp (snd $2) $3 $5 (Span.extend $1 $6)] }
     | SYMBOLIC SIZE ID SEMI                 { [dsize_sp (snd $3) None (Span.extend $1 $4)] }
     | SIZE ID ASSIGN size SEMI              { [dsize_sp (snd $2) (Some (snd $4)) (Span.extend $1 $5)] }
-    | GROUP ID ASSIGN LBRACE args RBRACE SEMI { [group_sp (snd $2) $5 (Span.extend $1 $7)] }
     | MODULE ID LBRACE decls RBRACE         { [module_sp (snd $2) [] $4 (Span.extend $1 $5)] }
     | MODULE ID COLON LBRACE interface RBRACE LBRACE decls RBRACE
                                             { [module_sp (snd $2) $5 $8 (Span.extend $1 $9)] }

--- a/src/lib/frontend/Parser.mly
+++ b/src/lib/frontend/Parser.mly
@@ -27,6 +27,17 @@
     if String.equal (Id.name id) "_" then PWild
     else failwith "Parse error: identifiers not allowed in patterns"
 
+  let make_group es span =
+    let locs = List.map
+        (fun e ->
+          match e.e with
+          | EInt (n, _) -> Z.to_int n
+          | _ -> Console.error_position span @@
+            "Group entries must be integers, not " ^ Printing.exp_to_string e)
+        es
+    in
+    value_sp (VGroup locs) span |> value_to_exp
+
 %}
 
 %token <Span.t * Id.t> ID
@@ -214,7 +225,7 @@ exp:
     | SIZECAST LPAREN size RPAREN             { szcast_sp (IConst 32) (snd $3) (Span.extend $1 $4) }
     | SIZECAST single_poly LPAREN size RPAREN { szcast_sp (snd $2) (snd $4) (Span.extend $1 $5) }
     | FLOOD exp                           { flood_sp $2 (Span.extend $1 $2.espan) }
-    | LBRACE args RBRACE                  { group_sp $2 (Span.extend $1 $3) }
+    | LBRACE args RBRACE                  { make_group $2 (Span.extend $1 $3) }
 
 exps:
   | exp                                 { [$1] }

--- a/src/lib/frontend/Parser.mly
+++ b/src/lib/frontend/Parser.mly
@@ -73,6 +73,7 @@
 %token <Span.t> MEVENT
 %token <Span.t> GENERATE
 %token <Span.t> MGENERATE
+%token <Span.t> PGENERATE
 %token <Span.t> TINT
 %token <Span.t> GLOBAL
 %token <Span.t> CONST
@@ -369,8 +370,9 @@ statement1:
     | ID ASSIGN exp SEMI	                  { sassign_sp (snd $1) $3 (Span.extend (fst $1) $4) }
     | RETURN SEMI                           { sret_sp None (Span.extend $1 $2) }
     | RETURN exp SEMI                       { sret_sp (Some $2) (Span.extend $1 $3) }
-    | GENERATE exp SEMI                     { gen_sp false $2 (Span.extend $1 $3)}
-    | MGENERATE exp SEMI                    { gen_sp true $2 (Span.extend $1 $3)}
+    | GENERATE exp SEMI                     { gen_sp GSingle $2 (Span.extend $1 $3)}
+    | MGENERATE exp SEMI                    { gen_sp GMulti $2 (Span.extend $1 $3)}
+    | PGENERATE LPAREN exp COMMA exp RPAREN SEMI { gen_sp (GPort $5) $3 (Span.extend $1 $7)}
     | cid paren_args SEMI                   { scall_sp (snd $1) (snd $2) (Span.extend (fst $1) $3) }
     | MATCH args WITH branches              { match_sp $2 (snd $4) (Span.extend $1 (fst $4)) }
     | MATCH LPAREN multiargs RPAREN WITH branches  { match_sp $3 (snd $6) (Span.extend $1 (fst $6)) }

--- a/src/lib/frontend/Parser.mly
+++ b/src/lib/frontend/Parser.mly
@@ -106,6 +106,7 @@
 %token <Span.t> SATPLUS
 %token <Span.t> BITNOT
 %token <Span.t> SYMBOLIC
+%token <Span.t> FLOOD
 
 %token EOF
 
@@ -119,7 +120,7 @@
 %left CONCAT
 %left BITAND BITXOR PIPE LSHIFT RSHIFT
 %nonassoc PROJ
-%right NOT BITNOT RPAREN
+%right NOT FLOOD BITNOT RPAREN
 %right LBRACKET /* highest precedence */
 
 
@@ -212,6 +213,7 @@ exp:
     | LBRACKET exps RBRACKET              { vector_sp $2 (Span.extend $1 $3) }
     | SIZECAST LPAREN size RPAREN             { szcast_sp (IConst 32) (snd $3) (Span.extend $1 $4) }
     | SIZECAST single_poly LPAREN size RPAREN { szcast_sp (snd $2) (snd $4) (Span.extend $1 $5) }
+    | FLOOD exp { flood_sp $2 (Span.extend $1 $2.espan) }
 
 exps:
   | exp                                 { [$1] }

--- a/src/lib/frontend/Printing.ml
+++ b/src/lib/frontend/Printing.ml
@@ -259,6 +259,7 @@ let rec e_to_string e =
     Printf.sprintf "%s(%s)" (cid_to_string cid) (es_to_string es)
   | EHash (size, es) ->
     Printf.sprintf "hash<<%s>>(%s)" (size_to_string size) (es_to_string es)
+  | EFlood e -> Printf.sprintf "flood %s" (exp_to_string e)
   | EProj (e, l) -> exp_to_string e ^ "#" ^ l
   | ERecord lst ->
     Printf.sprintf
@@ -307,7 +308,7 @@ and stmt_to_string s =
       let gen_str, loc =
         match g with
         | GSingle eo -> "generate_switch", Option.get eo
-        | GMulti loc -> "generate_multi", loc
+        | GMulti loc -> "generate_ports", loc
         | GPort loc -> "generate_port", loc
       in
       Printf.sprintf

--- a/src/lib/frontend/Printing.ml
+++ b/src/lib/frontend/Printing.ml
@@ -300,24 +300,19 @@ and stmt_to_string s =
   match s.s with
   | SAssign (i, e) -> id_to_string i ^ " = " ^ exp_to_string e ^ ";"
   | SNoop -> ""
-  | SGen (b, e) ->
-    (match b with
-    | GSingle eo ->
-      (match eo with
-      | None -> Printf.sprintf "generate %s;" (exp_to_string e)
-      | Some loc ->
-        Printf.sprintf
-          "generate_single (%s, %s)"
-          (exp_to_string loc)
-          (exp_to_string e))
-    | GMulti loc ->
+  | SGen (g, e) ->
+    (match g with
+    | GSingle None -> Printf.sprintf "generate %s;" (exp_to_string e)
+    | _ ->
+      let gen_str, loc =
+        match g with
+        | GSingle eo -> "generate_switch", Option.get eo
+        | GMulti loc -> "generate_multi", loc
+        | GPort loc -> "generate_port", loc
+      in
       Printf.sprintf
-        "generate_multi (%s, %s);"
-        (exp_to_string loc)
-        (exp_to_string e)
-    | GPort loc ->
-      Printf.sprintf
-        "generate_port (%s, %s);"
+        "%s (%s, %s);"
+        gen_str
         (exp_to_string loc)
         (exp_to_string e))
   | SLocal (i, t, e) ->

--- a/src/lib/frontend/Printing.ml
+++ b/src/lib/frontend/Printing.ml
@@ -259,6 +259,7 @@ let rec e_to_string e =
     Printf.sprintf "%s(%s)" (cid_to_string cid) (es_to_string es)
   | EHash (size, es) ->
     Printf.sprintf "hash<<%s>>(%s)" (size_to_string size) (es_to_string es)
+  | EGroup es -> Printf.sprintf "{%s}" (comma_sep exp_to_string es)
   | EFlood e -> Printf.sprintf "flood %s" (exp_to_string e)
   | EProj (e, l) -> exp_to_string e ^ "#" ^ l
   | ERecord lst ->
@@ -461,11 +462,6 @@ and d_to_string d =
     Printf.sprintf "extern %s %s;" (id_to_string id) (ty_to_string ty)
   | DSymbolic (id, ty) ->
     Printf.sprintf "symbolic %s %s;" (id_to_string id) (ty_to_string ty)
-  | DGroup (id, es) ->
-    Printf.sprintf
-      "group %s = {%s};"
-      (id_to_string id)
-      (comma_sep exp_to_string es)
   | DUserTy (id, sizes, ty) ->
     Printf.sprintf
       "type %s%s = %s"

--- a/src/lib/frontend/Printing.ml
+++ b/src/lib/frontend/Printing.ml
@@ -11,7 +11,7 @@ let integer_to_string n =
   if cfg.verbose_types then Integer.to_string n else Integer.value_string n
 ;;
 
-let location_to_string l = integer_to_string l
+let location_to_string l = string_of_int l
 let id_to_string id = if cfg.verbose_types then Id.to_string id else Id.name id
 
 let cid_to_string cid =
@@ -259,7 +259,6 @@ let rec e_to_string e =
     Printf.sprintf "%s(%s)" (cid_to_string cid) (es_to_string es)
   | EHash (size, es) ->
     Printf.sprintf "hash<<%s>>(%s)" (size_to_string size) (es_to_string es)
-  | EGroup es -> Printf.sprintf "{%s}" (comma_sep exp_to_string es)
   | EFlood e -> Printf.sprintf "flood %s" (exp_to_string e)
   | EProj (e, l) -> exp_to_string e ^ "#" ^ l
   | ERecord lst ->

--- a/src/lib/frontend/Printing.ml
+++ b/src/lib/frontend/Printing.ml
@@ -308,7 +308,14 @@ and stmt_to_string s =
   | SAssign (i, e) -> id_to_string i ^ " = " ^ exp_to_string e ^ ";"
   | SNoop -> ""
   | SGen (b, e) ->
-    Printf.sprintf "%sgenerate %s;" (if b then "m" else "") (exp_to_string e)
+    (match b with
+    | GSingle -> Printf.sprintf "generate %s;" (exp_to_string e)
+    | GMulti -> Printf.sprintf "mgenerate %s;" (exp_to_string e)
+    | GPort p ->
+      Printf.sprintf
+        "generate_port (%s, %s);"
+        (exp_to_string e)
+        (exp_to_string p))
   | SLocal (i, t, e) ->
     Printf.sprintf
       "%s %s = %s;"

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -152,6 +152,11 @@ and exp =
 
 and branch = pat list * statement
 
+and gen_type =
+  | GSingle
+  | GMulti
+  | GPort of exp
+
 (* statements *)
 and s =
   | SNoop
@@ -160,7 +165,7 @@ and s =
   | SAssign of id * exp
   | SPrintf of string * exp list
   | SIf of exp * statement * statement
-  | SGen of bool * exp (* Bool is true iff multicast *)
+  | SGen of gen_type * exp
   | SRet of exp option
   | SSeq of statement * statement
   | SMatch of exp list * branch list

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -13,7 +13,7 @@ and z = [%import: (Z.t[@opaque])]
 
 and zint = [%import: (Integer.t[@with Z.t := (Z.t [@opaque])])]
 
-and location = zint
+and location = int
 
 and size =
   | IConst of int
@@ -133,7 +133,6 @@ and e =
   | EOp of op * exp list
   | ECall of cid * exp list
   | EHash of size * exp list
-  | EGroup of exp list (* Group of ports *)
   | EFlood of exp (* Generate a group of all ports but one *)
   | ESizeCast of size * size (* Cast a size to int *)
   | EStmt of statement * exp
@@ -351,7 +350,6 @@ let index_sp lst idx span = exp_sp (EIndex (lst, idx)) span
 let comp_sp e i k span = exp_sp (EComp (e, i, k)) span
 let vector_sp es span = exp_sp (EVector es) span
 let szcast_sp sz1 sz2 span = exp_sp (ESizeCast (sz1, sz2)) span
-let group_sp es span = exp_sp (EGroup es) span
 let flood_sp e span = exp_sp (EFlood e) span
 
 (* declarations *)

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -133,6 +133,7 @@ and e =
   | EOp of op * exp list
   | ECall of cid * exp list
   | EHash of size * exp list
+  | EFlood of exp (* Generate a group of all ports but one *)
   | ESizeCast of size * size (* Cast a size to int *)
   | EStmt of statement * exp
   | ERecord of (string * exp) list
@@ -350,6 +351,7 @@ let index_sp lst idx span = exp_sp (EIndex (lst, idx)) span
 let comp_sp e i k span = exp_sp (EComp (e, i, k)) span
 let vector_sp es span = exp_sp (EVector es) span
 let szcast_sp sz1 sz2 span = exp_sp (ESizeCast (sz1, sz2)) span
+let flood_sp e span = exp_sp (EFlood e) span
 
 (* declarations *)
 let decl d = { d; dspan = Span.default }

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -47,7 +47,7 @@ and raw_ty =
   | TVoid
   | TGroup
   | TInt of size (* Number of bits *)
-  | TEvent of bool (* True iff multicast *)
+  | TEvent
   | TFun of func_ty
   | TMemop of size * size
   | TName of cid * sizes * bool (* Named type: e.g. "Array.t<<32>>". Bool is true if it represents a global type *)
@@ -117,7 +117,6 @@ and event =
   { eid : cid
   ; data : value list
   ; edelay : int
-  ; elocations : location list
   }
 
 and value =
@@ -153,8 +152,8 @@ and exp =
 and branch = pat list * statement
 
 and gen_type =
-  | GSingle
-  | GMulti
+  | GSingle of exp option (* switch id *)
+  | GMulti of exp (* Multicast group name *)
   | GPort of exp
 
 (* statements *)

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -133,6 +133,7 @@ and e =
   | EOp of op * exp list
   | ECall of cid * exp list
   | EHash of size * exp list
+  | EGroup of exp list (* Group of ports *)
   | EFlood of exp (* Generate a group of all ports but one *)
   | ESizeCast of size * size (* Cast a size to int *)
   | EStmt of statement * exp
@@ -211,7 +212,6 @@ and d =
   | DFun of id * ty * constr_spec list * body
   | DMemop of id * body
   | DConst of id * ty * exp
-  | DGroup of id * exp list
   | DExtern of id * ty
   | DSymbolic of id * ty
   | DUserTy of id * sizes * ty
@@ -351,6 +351,7 @@ let index_sp lst idx span = exp_sp (EIndex (lst, idx)) span
 let comp_sp e i k span = exp_sp (EComp (e, i, k)) span
 let vector_sp es span = exp_sp (EVector es) span
 let szcast_sp sz1 sz2 span = exp_sp (ESizeCast (sz1, sz2)) span
+let group_sp es span = exp_sp (EGroup es) span
 let flood_sp e span = exp_sp (EFlood e) span
 
 (* declarations *)
@@ -364,7 +365,6 @@ let handler_sp id p body span = decl_sp (DHandler (id, (p, body))) span
 let dsize_sp id size span = decl_sp (DSize (id, size)) span
 let fun_sp id rty cs p body span = decl_sp (DFun (id, rty, cs, (p, body))) span
 let memop_sp id p body span = decl_sp (DMemop (id, (p, body))) span
-let group_sp id es span = decl_sp (DGroup (id, es)) span
 let duty_sp id sizes rty span = decl_sp (DUserTy (id, sizes, rty)) span
 
 let dconstr_sp id ty params exp span =

--- a/src/lib/frontend/SyntaxUtils.ml
+++ b/src/lib/frontend/SyntaxUtils.ml
@@ -292,7 +292,7 @@ let rec is_compound e =
   match e.e with
   | EInt _ | EVal _ | EVar _ | ESizeCast _ -> false
   | EHash _ | EOp _ | ECall _ | EStmt _ -> true
-  | EComp (e, _, _) | EIndex (e, _) | EProj (e, _) -> is_compound e
+  | EComp (e, _, _) | EIndex (e, _) | EProj (e, _) | EFlood e -> is_compound e
   | EVector entries | ETuple entries -> List.exists is_compound entries
   | ERecord entries -> List.exists (is_compound % snd) entries
   | EWith (base, entries) ->

--- a/src/lib/frontend/SyntaxUtils.ml
+++ b/src/lib/frontend/SyntaxUtils.ml
@@ -293,8 +293,7 @@ let rec is_compound e =
   | EInt _ | EVal _ | EVar _ | ESizeCast _ -> false
   | EHash _ | EOp _ | ECall _ | EStmt _ -> true
   | EComp (e, _, _) | EIndex (e, _) | EProj (e, _) | EFlood e -> is_compound e
-  | EVector entries | ETuple entries | EGroup entries ->
-    List.exists is_compound entries
+  | EVector entries | ETuple entries -> List.exists is_compound entries
   | ERecord entries -> List.exists (is_compound % snd) entries
   | EWith (base, entries) ->
     is_compound base || List.exists (is_compound % snd) entries

--- a/src/lib/frontend/SyntaxUtils.ml
+++ b/src/lib/frontend/SyntaxUtils.ml
@@ -183,9 +183,8 @@ let rec equiv_raw_ty ?(ignore_effects = false) ?(qvars_wild = false) ty1 ty2 =
   let equiv_raw_ty = equiv_raw_ty ~ignore_effects ~qvars_wild in
   let equiv_ty = equiv_ty ~ignore_effects ~qvars_wild in
   match ty1, ty2 with
-  | TBool, TBool | TVoid, TVoid | TGroup, TGroup -> true
+  | TBool, TBool | TVoid, TVoid | TGroup, TGroup | TEvent, TEvent -> true
   | TInt size1, TInt size2 -> equiv_size size1 size2
-  | TEvent b1, TEvent b2 -> b1 = b2
   | TMemop (size1, size2), TMemop (size3, size4) ->
     equiv_size size1 size3 && equiv_size size2 size4
   | TName (id1, sizes1, b1), TName (id2, sizes2, b2) ->
@@ -218,7 +217,7 @@ let rec equiv_raw_ty ?(ignore_effects = false) ?(qvars_wild = false) ty1 ty2 =
   | ( ( TBool
       | TMemop _
       | TInt _
-      | TEvent _
+      | TEvent
       | TName _
       | TFun _
       | TVoid
@@ -243,7 +242,7 @@ let max_effect e1 e2 =
 
 let rec is_global_rty rty =
   match TyTQVar.strip_links rty with
-  | TBool | TVoid | TGroup | TInt _ | TEvent _ | TFun _ | TMemop _ -> false
+  | TBool | TVoid | TGroup | TInt _ | TEvent | TFun _ | TMemop _ -> false
   | TQVar _ -> false (* I think *)
   | TName (_, _, b) -> b
   | TTuple lst -> List.exists is_global_rty lst
@@ -256,7 +255,7 @@ let is_global ty = is_global_rty ty.raw_ty
 (* Similar to is_global_rty, but also returns false for TQVars *)
 let rec is_not_global_rty rty =
   match TyTQVar.strip_links rty with
-  | TBool | TVoid | TGroup | TInt _ | TEvent _ | TFun _ | TMemop _ -> true
+  | TBool | TVoid | TGroup | TInt _ | TEvent | TFun _ | TMemop _ -> true
   | TQVar _ -> false (* I think *)
   | TName (_, _, b) -> not b
   | TTuple lst -> List.for_all is_not_global_rty lst

--- a/src/lib/frontend/SyntaxUtils.ml
+++ b/src/lib/frontend/SyntaxUtils.ml
@@ -293,7 +293,8 @@ let rec is_compound e =
   | EInt _ | EVal _ | EVar _ | ESizeCast _ -> false
   | EHash _ | EOp _ | ECall _ | EStmt _ -> true
   | EComp (e, _, _) | EIndex (e, _) | EProj (e, _) | EFlood e -> is_compound e
-  | EVector entries | ETuple entries -> List.exists is_compound entries
+  | EVector entries | ETuple entries | EGroup entries ->
+    List.exists is_compound entries
   | ERecord entries -> List.exists (is_compound % snd) entries
   | EWith (base, entries) ->
     is_compound base || List.exists (is_compound % snd) entries

--- a/src/lib/frontend/Wellformed.ml
+++ b/src/lib/frontend/Wellformed.ml
@@ -14,7 +14,6 @@ open Printing
    - Only certain types allowed as externs (just ints? I guess bools too?)
    - All events have exactly one handler declared, which must be in the same scope as them.
    - All sizes in symbolic declarations are either concrete or symbolic themselves
-   - All non-flood group expressions are constant
 
    Checks we do during typechecking:
    - No dynamic global creation
@@ -159,26 +158,6 @@ let rec match_handlers ?(m_cid = None) (ds : decls) =
          "Handler %s has no corresponding event definition"
          (m_str ^ id_to_string id)
   | None, None -> ()
-;;
-
-let check_group_exps ds =
-  let v =
-    object
-      inherit [_] s_iter
-
-      method! visit_EGroup _ es =
-        List.iter
-          (function
-            | { e = EInt _ } -> ()
-            | e ->
-              Console.error_position e.espan
-              @@ Printf.sprintf
-                   "Group entries must be constant integers, not %s"
-                   (Printing.exp_to_string e))
-          es
-    end
-  in
-  v#visit_decls () ds
 ;;
 
 let pre_typing_checks ds =

--- a/src/lib/frontend/modules/Builtins.ml
+++ b/src/lib/frontend/modules/Builtins.ml
@@ -15,7 +15,7 @@ let builtin_defs = Arrays.defs @ Counters.defs @ Events.defs @ System.defs
 
 (* Not a global var *)
 let this_id = Id.create "this"
-let this_ty = ty @@ TEvent false
+let this_ty = TEvent |> ty
 
 (* Used in constraints *)
 let start_id = Id.create "start"

--- a/src/lib/frontend/modules/Builtins.ml
+++ b/src/lib/frontend/modules/Builtins.ml
@@ -16,6 +16,8 @@ let builtin_defs = Arrays.defs @ Counters.defs @ Events.defs @ System.defs
 (* Not a global var *)
 let this_id = Id.create "this"
 let this_ty = TEvent |> ty
+let ingr_port_id = Id.create "ingress_port"
+let ingr_port_ty = TInt (IConst 32) |> ty
 
 (* Used in constraints *)
 let start_id = Id.create "start"

--- a/src/lib/frontend/modules/Builtins.ml
+++ b/src/lib/frontend/modules/Builtins.ml
@@ -3,7 +3,9 @@ open Syntax
 (* Builtin variables *)
 let self_id = Id.create "self"
 let self_ty = ty (TInt (IConst 32))
-let builtin_vars = [self_id, self_ty]
+let recirc_id = Id.create "recirculation_port"
+let recirc_ty = ty (TInt (IConst 32))
+let builtin_vars = [self_id, self_ty; recirc_id, recirc_ty]
 let builtin_type_ids = [Arrays.t_id; Counters.t_id]
 
 (* Building modules *)

--- a/src/lib/frontend/modules/Events.ml
+++ b/src/lib/frontend/modules/Events.ml
@@ -16,126 +16,34 @@ let event_delay_id = Id.create event_delay_name
 let event_delay_cid = Cid.create_ids [event_id; event_delay_id]
 let event_delay_error msg = event_error event_delay_name msg
 
-let delay_fun err _ _ args =
+let event_delay_fun _ _ args =
   let open CoreSyntax in
   let open State in
   match args with
   | [V { v = VEvent event }; V { v = VInt delay }] ->
     let delay = Integer.to_int delay in
     if delay < 0
-    then err "Interpreter: Cannot create an event with negative delay"
+    then
+      event_error
+        event_delay_name
+        "Interpreter: Cannot create an event with negative delay"
     else vevent { event with edelay = delay }
-  | _ -> err "Incorrect number of type of events to Event.delay"
+  | _ ->
+    event_error event_delay_name "Incorrect number of arguments to Event.delay"
 ;;
 
-let event_delay_fun = delay_fun event_delay_error
-
-let delay_ty b =
+let event_delay_ty =
   let eff = FVar (QVar (Id.fresh "eff")) in
   ty
   @@ TFun
-       { arg_tys = [ty @@ TEvent b; ty @@ TInt (IConst 32)]
-       ; ret_ty = ty @@ TEvent b
+       { arg_tys = [ty TEvent; ty @@ TInt (IConst 32)]
+       ; ret_ty = ty TEvent
        ; start_eff = eff
        ; end_eff = eff
        ; constraints = ref []
        }
 ;;
-
-let event_delay_ty = delay_ty false
-
-(* Event.mdelay *)
-let event_mdelay_name = "mdelay"
-let event_mdelay_id = Id.create event_mdelay_name
-let event_mdelay_cid = Cid.create_ids [event_id; event_mdelay_id]
-let event_mdelay_error msg = event_error event_mdelay_name msg
-let event_mdelay_ty = delay_ty true
-let event_mdelay_fun = delay_fun event_mdelay_error
-
-(* Event.sslocate *)
-let event_sslocate_name = "sslocate"
-let event_sslocate_id = Id.create event_sslocate_name
-let event_sslocate_cid = Cid.create_ids [event_id; event_sslocate_id]
-let event_sslocate_error msg = event_error event_sslocate_name msg
-
-let locate_fun err nst _ args =
-  (* Hack to make the types work *)
-  let err str = failwith (err str) in
-  let open CoreSyntax in
-  let open State in
-  let event, locations =
-    match args with
-    | [V { v = VEvent event }; V { v = VInt location }] -> event, [location]
-    | [V { v = VEvent event }; V { v = VGroup locations }] -> event, locations
-    | _ -> err "Incorrect number of type of events to Event.locate"
-  in
-  List.iter
-    (fun location ->
-      let location = Integer.to_int location in
-      if location < 0 || location >= Array.length nst.switches
-      then err @@ Printf.sprintf "invalid location %d" location)
-    locations;
-  vevent { event with elocations = locations }
-;;
-
-let event_sslocate_fun = locate_fun event_sslocate_error
-
-let locate_ty in_b out_b =
-  let eff = FVar (QVar (Id.fresh "eff")) in
-  let argty = if out_b then TGroup else TInt (IConst 32) in
-  ty
-  @@ TFun
-       { arg_tys = [ty @@ TEvent in_b; ty argty]
-       ; ret_ty = ty @@ TEvent out_b
-       ; start_eff = eff
-       ; end_eff = eff
-       ; constraints = ref []
-       }
-;;
-
-let event_sslocate_ty = locate_ty false false
-
-(* Event.smlocate *)
-let event_smlocate_name = "smlocate"
-let event_smlocate_id = Id.create event_smlocate_name
-let event_smlocate_cid = Cid.create_ids [event_id; event_smlocate_id]
-let event_smlocate_error msg = event_error event_smlocate_name msg
-let event_smlocate_fun = locate_fun event_smlocate_error
-let event_smlocate_ty = locate_ty false true
-
-(* Event.mslocate *)
-let event_mslocate_name = "mslocate"
-let event_mslocate_id = Id.create event_mslocate_name
-let event_mslocate_cid = Cid.create_ids [event_id; event_mslocate_id]
-let event_mslocate_error msg = event_error event_mslocate_name msg
-let event_mslocate_fun = locate_fun event_mslocate_error
-let event_mslocate_ty = locate_ty true false
-
-(* Event.mmlocate *)
-let event_mmlocate_name = "mmlocate"
-let event_mmlocate_id = Id.create event_mmlocate_name
-let event_mmlocate_cid = Cid.create_ids [event_id; event_mmlocate_id]
-let event_mmlocate_error msg = event_error event_mmlocate_name msg
-let event_mmlocate_fun = locate_fun event_mmlocate_error
-let event_mmlocate_ty = locate_ty true true
 
 let defs : State.global_fun list =
-  [ { cid = event_delay_cid; body = event_delay_fun; ty = event_delay_ty }
-  ; { cid = event_mdelay_cid; body = event_mdelay_fun; ty = event_mdelay_ty }
-  ; { cid = event_sslocate_cid
-    ; body = event_sslocate_fun
-    ; ty = event_sslocate_ty
-    }
-  ; { cid = event_smlocate_cid
-    ; body = event_smlocate_fun
-    ; ty = event_smlocate_ty
-    }
-  ; { cid = event_mslocate_cid
-    ; body = event_mslocate_fun
-    ; ty = event_mslocate_ty
-    }
-  ; { cid = event_mmlocate_cid
-    ; body = event_mmlocate_fun
-    ; ty = event_mmlocate_ty
-    } ]
+  [{ cid = event_delay_cid; body = event_delay_fun; ty = event_delay_ty }]
 ;;

--- a/src/lib/frontend/transformations/EStmtElimination.ml
+++ b/src/lib/frontend/transformations/EStmtElimination.ml
@@ -18,9 +18,6 @@ let rec inline_exp e =
   | EHash (sz, es) ->
     let stmt, es' = inline_exps es in
     stmt, { e with e = EHash (sz, es') }
-  | EGroup es ->
-    let stmt, es' = inline_exps es in
-    stmt, { e with e = EGroup es' }
   | EFlood e ->
     let stmt, e' = inline_exp e in
     stmt, { e with e = EFlood e' }

--- a/src/lib/frontend/transformations/EStmtElimination.ml
+++ b/src/lib/frontend/transformations/EStmtElimination.ml
@@ -18,6 +18,9 @@ let rec inline_exp e =
   | EHash (sz, es) ->
     let stmt, es' = inline_exps es in
     stmt, { e with e = EHash (sz, es') }
+  | EFlood e ->
+    let stmt, e' = inline_exp e in
+    stmt, { e with e = EFlood e' }
   | ERecord lst ->
     let strs, es = List.split lst in
     let stmt, es = inline_exps es in

--- a/src/lib/frontend/transformations/EStmtElimination.ml
+++ b/src/lib/frontend/transformations/EStmtElimination.ml
@@ -18,6 +18,9 @@ let rec inline_exp e =
   | EHash (sz, es) ->
     let stmt, es' = inline_exps es in
     stmt, { e with e = EHash (sz, es') }
+  | EGroup es ->
+    let stmt, es' = inline_exps es in
+    stmt, { e with e = EGroup es' }
   | EFlood e ->
     let stmt, e' = inline_exp e in
     stmt, { e with e = EFlood e' }

--- a/src/lib/frontend/transformations/FunctionInlining.ml
+++ b/src/lib/frontend/transformations/FunctionInlining.ml
@@ -209,13 +209,7 @@ let inline_decl env d =
   | DGlobal (id, ty, e) ->
     env, Some { d with d = DGlobal (id, ty, inliner#visit_exp env e) }
     (* Other stuff is unaffected *)
-  | DUserTy _
-  | DExtern _
-  | DSymbolic _
-  | DEvent _
-  | DConst _
-  | DGroup _
-  | DSize _ ->
+  | DUserTy _ | DExtern _ | DSymbolic _ | DEvent _ | DConst _ | DSize _ ->
     (* We can't inline an exp that's not part of a statement *) env, Some d
   | DMemop _ ->
     (* No function calls allowed in Memops *)

--- a/src/lib/frontend/transformations/ModuleElimination.ml
+++ b/src/lib/frontend/transformations/ModuleElimination.ml
@@ -61,7 +61,6 @@ let add_definitions prefix env ds =
     | DExtern (id, _)
     | DSymbolic (id, _)
     | DFun (id, _, _, _)
-    | DGroup (id, _)
     | DMemop (id, _)
     | DEvent (id, _, _, _)
     | DHandler (id, _)
@@ -113,9 +112,6 @@ let rec replace_module env m_id ds =
           | DFun (id, x, y, z) ->
             ( { env with vars = add_entry env.vars id }
             , DFun (prefix id, x, y, z) |> wrap d )
-          | DGroup (id, x) ->
-            ( { env with vars = add_entry env.vars id }
-            , DGroup (prefix id, x) |> wrap d )
           | DMemop (id, x) ->
             ( { env with vars = add_entry env.vars id }
             , DMemop (prefix id, x) |> wrap d )

--- a/src/lib/frontend/transformations/Renaming.ml
+++ b/src/lib/frontend/transformations/Renaming.ml
@@ -258,10 +258,6 @@ let rename prog =
           let new_ty = self#visit_ty dummy ty in
           let new_x = self#freshen_var x in
           DSymbolic (new_x, new_ty)
-        | DGroup (x, es) ->
-          let new_es = List.map (self#visit_exp dummy) es in
-          let new_x = self#freshen_var x in
-          DGroup (new_x, new_es)
         | DUserTy (id, sizes, ty) ->
           let new_sizes = List.map (self#visit_size ()) sizes in
           let new_ty = self#visit_ty () ty in

--- a/src/lib/frontend/transformations/Renaming.ml
+++ b/src/lib/frontend/transformations/Renaming.ml
@@ -92,7 +92,7 @@ let rename prog =
           List.fold_left
             (fun env id -> CidMap.add (Id id) (Id id) env)
             CidMap.empty
-            (start_id :: this_id :: List.map fst builtin_vars)
+            (start_id :: ingr_port_id :: this_id :: List.map fst builtin_vars)
         in
         let builtin_cids =
           List.map fst (Arrays.constructors @ Counters.constructors)

--- a/src/lib/frontend/transformations/TupleElimination.ml
+++ b/src/lib/frontend/transformations/TupleElimination.ml
@@ -196,13 +196,8 @@ let rec replace_decl (env : env) d =
     let body_env, new_params = flatten_params env params in
     let body = replace_statement body_env body in
     env, [{ d with d = DHandler (id, (new_params, body)) }]
-  | DSize _
-  | DMemop _
-  | DGroup _
-  | DExtern _
-  | DSymbolic _
-  | DConst _
-  | DGlobal _ -> env, [d]
+  | DSize _ | DMemop _ | DExtern _ | DSymbolic _ | DConst _ | DGlobal _ ->
+    env, [d]
   | DFun _ | DConstr _ | DModule _ | DUserTy _ ->
     Console.error_position
       d.dspan

--- a/src/lib/frontend/typing/Typer.ml
+++ b/src/lib/frontend/typing/Typer.ml
@@ -39,8 +39,8 @@ let infer_value v =
     match v.v with
     | VBool _ -> TBool
     | VInt n -> TInt (IConst (Integer.size n))
-    | VGlobal _ | VEvent _ | VGroup _ ->
-      failwith "Cannot write values of these types"
+    | VGroup _ -> TGroup
+    | VGlobal _ | VEvent _ -> failwith "Cannot write values of these types"
   in
   { v with vty = Some (mk_ty vty) }
 ;;
@@ -84,13 +84,6 @@ let rec infer_exp (env : env) (e : exp) : env * exp =
     let hd = List.hd inf_es in
     unify_ty hd.espan (Option.get hd.ety) (mk_ty @@ TInt (fresh_size ()));
     env, { e with e = EHash (size, inf_es); ety = Some (mk_ty @@ TInt size) }
-  | EGroup es ->
-    let env, inf_es = infer_exps env es in
-    List.iter
-      (fun e ->
-        unify_ty e.espan (Option.get e.ety) (mk_ty @@ TInt (fresh_size ())))
-      inf_es;
-    env, { e with e = EGroup inf_es; ety = Some (mk_ty @@ TGroup) }
   | EFlood e1 ->
     let env, inf_e, inf_ety = infer_exp env e1 |> textract in
     unify_ty e.espan inf_ety (mk_ty @@ TInt (fresh_size ()));

--- a/src/lib/frontend/typing/Typer.ml
+++ b/src/lib/frontend/typing/Typer.ml
@@ -892,7 +892,9 @@ let rec infer_declaration (env : env) (effect_count : effect) (d : decl)
           { env with
             current_effect = FZero
           ; consts =
-              CidMap.add (Id Builtins.this_id) Builtins.this_ty env.consts
+              env.consts
+              |> CidMap.add (Id Builtins.this_id) Builtins.this_ty
+              |> CidMap.add (Id Builtins.ingr_port_id) Builtins.ingr_port_ty
           ; constraints
           }
           body

--- a/src/lib/frontend/typing/Typer.ml
+++ b/src/lib/frontend/typing/Typer.ml
@@ -84,6 +84,10 @@ let rec infer_exp (env : env) (e : exp) : env * exp =
     let hd = List.hd inf_es in
     unify_ty hd.espan (Option.get hd.ety) (mk_ty @@ TInt (fresh_size ()));
     env, { e with e = EHash (size, inf_es); ety = Some (mk_ty @@ TInt size) }
+  | EFlood e1 ->
+    let env, inf_e, inf_ety = infer_exp env e1 |> textract in
+    unify_ty e.espan inf_ety (mk_ty @@ TInt (fresh_size ()));
+    env, { e with e = EFlood inf_e; ety = Some (mk_ty @@ TGroup) }
   | ECall (f, args) ->
     let _, _, inferred_fty =
       (* Get type of f as if we used the var rule for the function *)

--- a/src/lib/frontend/typing/Typer.ml
+++ b/src/lib/frontend/typing/Typer.ml
@@ -576,19 +576,22 @@ and infer_statement (env : env) (s : statement) : env * statement =
       { env with current_effect }, SIf (inf_e, inf_s1, inf_s2)
     | SGen (g, e) ->
       let env, inf_e, ety = infer_exp env e |> textract in
+      unify_raw_ty s.sspan ety.raw_ty TEvent;
       let env, inf_g =
         match g with
-        | GSingle ->
-          unify_raw_ty s.sspan ety.raw_ty (TEvent false);
-          env, g
-        | GMulti ->
-          unify_raw_ty s.sspan ety.raw_ty (TEvent true);
-          env, g
-        | GPort e ->
-          unify_raw_ty s.sspan ety.raw_ty (TEvent false);
-          let env, inf_e, ety = infer_exp env e |> textract in
-          unify_raw_ty s.sspan ety.raw_ty (TInt (fresh_size ()));
-          env, GPort inf_e
+        | GSingle None -> env, g
+        | GSingle (Some loc) ->
+          let env, inf_loc, lty = infer_exp env loc |> textract in
+          unify_raw_ty s.sspan lty.raw_ty (TInt (fresh_size ()));
+          env, GSingle (Some inf_loc)
+        | GMulti loc ->
+          let env, inf_loc, lty = infer_exp env loc |> textract in
+          unify_raw_ty s.sspan lty.raw_ty TGroup;
+          env, GMulti inf_loc
+        | GPort loc ->
+          let env, inf_loc, lty = infer_exp env loc |> textract in
+          unify_raw_ty s.sspan lty.raw_ty (TInt (fresh_size ()));
+          env, GPort inf_loc
       in
       env, SGen (inf_g, inf_e)
     | SSeq (s1, s2) ->

--- a/src/lib/frontend/typing/TyperModules.ml
+++ b/src/lib/frontend/typing/TyperModules.ml
@@ -278,7 +278,7 @@ let rec validate_interface prefix env interface =
                (Printing.id_to_string id);
         let expected_fty =
           { arg_tys = List.map snd params
-          ; ret_ty = ty @@ TEvent false
+          ; ret_ty = ty TEvent
           ; start_eff = func_ty.start_eff
           ; end_eff = func_ty.start_eff
           ; constraints = ref !(func_ty.constraints)

--- a/src/lib/frontend/typing/TyperUnify.ml
+++ b/src/lib/frontend/typing/TyperUnify.ml
@@ -61,7 +61,7 @@ let occurs_ty span tvar raw_ty : unit =
   let rec occ tvar raw_ty =
     match raw_ty with
     | TQVar tvr -> occurs_tqvar occ tvar tvr
-    | TBool | TInt _ | TName _ | TVoid | TEvent _ | TGroup | TMemop _ -> ()
+    | TBool | TInt _ | TName _ | TVoid | TEvent | TGroup | TMemop _ -> ()
     | TRecord lst -> List.iter (fun (_, raw_ty) -> occ tvar raw_ty) lst
     | TTuple lst -> List.iter (occ tvar) lst
     | TFun { arg_tys; ret_ty; _ } ->
@@ -208,12 +208,11 @@ and try_unify_rty span rty1 rty2 =
       TyTQVar.phys_equiv_tqvar
       tqv
       ty
-  | TBool, TBool | TVoid, TVoid | TGroup, TGroup -> ()
+  | TBool, TBool | TVoid, TVoid | TGroup, TGroup | TEvent, TEvent -> ()
   | TInt size1, TInt size2 -> try_unify_size span size1 size2
   | TMemop (size1a, size1b), TMemop (size2a, size2b) ->
     try_unify_size span size1a size2a;
     try_unify_size span size1b size2b
-  | TEvent b1, TEvent b2 -> if b1 <> b2 then raise CannotUnify
   | TName (cid1, sizes1, b1), TName (cid2, sizes2, b2) ->
     if b1 <> b2 || not (Cid.equal cid1 cid2) then raise CannotUnify;
     List.iter2 (try_unify_size span) sizes1 sizes2
@@ -240,9 +239,9 @@ and try_unify_rty span rty1 rty2 =
   | ( ( TVoid
       | TGroup
       | TBool
+      | TEvent
       | TInt _
       | TMemop _
-      | TEvent _
       | TName _
       | TFun _
       | TRecord _

--- a/src/lib/frontend/typing/TyperUtil.ml
+++ b/src/lib/frontend/typing/TyperUtil.ml
@@ -217,7 +217,7 @@ let mk_event_ty constrs params =
   ty
   @@ TFun
        { arg_tys = List.map snd params
-       ; ret_ty = ty (TEvent false) (* Events are singlecast by default *)
+       ; ret_ty = ty TEvent
        ; start_eff = eff
        ; end_eff = eff
        ; constraints = ref constrs

--- a/src/lib/midend/CorePrinting.ml
+++ b/src/lib/midend/CorePrinting.ml
@@ -155,7 +155,14 @@ and stmt_to_string s =
   | SAssign (i, e) -> id_to_string i ^ " = " ^ exp_to_string e ^ ";"
   | SNoop -> ""
   | SGen (b, e) ->
-    Printf.sprintf "%sgenerate %s;" (if b then "m" else "") (exp_to_string e)
+    (match b with
+    | GSingle -> Printf.sprintf "generate %s;" (exp_to_string e)
+    | GMulti -> Printf.sprintf "mgenerate %s;" (exp_to_string e)
+    | GPort p ->
+      Printf.sprintf
+        "generate_port (%s, %s);"
+        (exp_to_string e)
+        (exp_to_string p))
   | SLocal (i, t, e) ->
     Printf.sprintf
       "%s %s = %s;"

--- a/src/lib/midend/CorePrinting.ml
+++ b/src/lib/midend/CorePrinting.ml
@@ -31,7 +31,7 @@ let rec raw_ty_to_string t =
     cid_to_string cid
     ^ sizes_to_string sizes
     ^ if cfg.verbose_types then "{" ^ string_of_bool b ^ "}" else ""
-  | TEvent b -> if b then "mevent" else "event"
+  | TEvent -> "event"
   | TFun func -> func_to_string func
   | TMemop (size1, size2) ->
     Printf.sprintf
@@ -101,24 +101,17 @@ let rec v_to_string v =
 
 and value_to_string v = v_to_string v.v
 
-and event_to_string { eid; data; edelay; elocations } =
-  let locstr =
-    match elocations with
-    | [] -> "self"
-    | _ -> list_to_string location_to_string elocations
-  in
-  let locstr = if cfg.verbose_types then "@" ^ locstr else "" in
+and event_to_string { eid; data; edelay } =
   let delaystr =
     if edelay <> 0 && cfg.verbose_types
     then "@" ^ string_of_int edelay ^ "ns"
     else ""
   in
   Printf.sprintf
-    "%s(%s)%s%s"
+    "%s(%s)%s"
     (cid_to_string eid)
     (comma_sep value_to_string data)
     delaystr
-    locstr
 ;;
 
 let rec e_to_string e =
@@ -154,15 +147,21 @@ and stmt_to_string s =
   match s.s with
   | SAssign (i, e) -> id_to_string i ^ " = " ^ exp_to_string e ^ ";"
   | SNoop -> ""
-  | SGen (b, e) ->
-    (match b with
-    | GSingle -> Printf.sprintf "generate %s;" (exp_to_string e)
-    | GMulti -> Printf.sprintf "mgenerate %s;" (exp_to_string e)
-    | GPort p ->
+  | SGen (g, e) ->
+    (match g with
+    | GSingle None -> Printf.sprintf "generate %s;" (exp_to_string e)
+    | _ ->
+      let gen_str, loc =
+        match g with
+        | GSingle eo -> "generate_switch", Option.get eo
+        | GMulti loc -> "generate_multi", loc
+        | GPort loc -> "generate_port", loc
+      in
       Printf.sprintf
-        "generate_port (%s, %s);"
-        (exp_to_string e)
-        (exp_to_string p))
+        "%s (%s, %s);"
+        gen_str
+        (exp_to_string loc)
+        (exp_to_string e))
   | SLocal (i, t, e) ->
     Printf.sprintf
       "%s %s = %s;"

--- a/src/lib/midend/CorePrinting.ml
+++ b/src/lib/midend/CorePrinting.ml
@@ -131,6 +131,7 @@ let rec e_to_string e =
   | EHash (size, es) ->
     Printf.sprintf "hash<<%s>>(%s)" (size_to_string size) (es_to_string es)
   | EFlood e -> Printf.sprintf "flood %s" (exp_to_string e)
+  | EGroup es -> Printf.sprintf "{%s}" (comma_sep exp_to_string es)
 
 and exp_to_string e = e_to_string e.e
 and es_to_string es = comma_sep exp_to_string es
@@ -239,11 +240,6 @@ let d_to_string d =
       (stmt_to_string s)
   | DExtern (id, ty) ->
     Printf.sprintf "extern %s %s;" (id_to_string id) (ty_to_string ty)
-  | DGroup (id, es) ->
-    Printf.sprintf
-      "group %s = {%s};"
-      (id_to_string id)
-      (comma_sep exp_to_string es)
 ;;
 
 let decl_to_string d = d_to_string d.d

--- a/src/lib/midend/CorePrinting.ml
+++ b/src/lib/midend/CorePrinting.ml
@@ -10,7 +10,7 @@ let integer_to_string n =
   if cfg.verbose_types then Integer.to_string n else Integer.value_string n
 ;;
 
-let location_to_string l = integer_to_string l
+let location_to_string l = string_of_int l
 let id_to_string id = if cfg.verbose_types then Id.to_string id else Id.name id
 
 let cid_to_string cid =
@@ -130,6 +130,7 @@ let rec e_to_string e =
     Printf.sprintf "%s(%s)" (cid_to_string cid) (es_to_string es)
   | EHash (size, es) ->
     Printf.sprintf "hash<<%s>>(%s)" (size_to_string size) (es_to_string es)
+  | EFlood e -> Printf.sprintf "flood %s" (exp_to_string e)
 
 and exp_to_string e = e_to_string e.e
 and es_to_string es = comma_sep exp_to_string es
@@ -154,7 +155,7 @@ and stmt_to_string s =
       let gen_str, loc =
         match g with
         | GSingle eo -> "generate_switch", Option.get eo
-        | GMulti loc -> "generate_multi", loc
+        | GMulti loc -> "generate_ports", loc
         | GPort loc -> "generate_port", loc
       in
       Printf.sprintf

--- a/src/lib/midend/CorePrinting.ml
+++ b/src/lib/midend/CorePrinting.ml
@@ -131,7 +131,6 @@ let rec e_to_string e =
   | EHash (size, es) ->
     Printf.sprintf "hash<<%s>>(%s)" (size_to_string size) (es_to_string es)
   | EFlood e -> Printf.sprintf "flood %s" (exp_to_string e)
-  | EGroup es -> Printf.sprintf "{%s}" (comma_sep exp_to_string es)
 
 and exp_to_string e = e_to_string e.e
 and es_to_string es = comma_sep exp_to_string es

--- a/src/lib/midend/CoreSyntax.ml
+++ b/src/lib/midend/CoreSyntax.ml
@@ -98,7 +98,6 @@ and e =
   | EOp of op * exp list
   | ECall of cid * exp list
   | EHash of size * exp list
-  | EGroup of exp list
   | EFlood of exp
 
 and exp =

--- a/src/lib/midend/CoreSyntax.ml
+++ b/src/lib/midend/CoreSyntax.ml
@@ -108,6 +108,11 @@ and exp =
 
 and branch = pat list * statement
 
+and gen_type =
+  | GSingle
+  | GMulti
+  | GPort of exp
+
 (* statements *)
 and s =
   | SNoop
@@ -116,7 +121,7 @@ and s =
   | SAssign of id * exp
   | SPrintf of string * exp list
   | SIf of exp * statement * statement
-  | SGen of bool * exp (* Bool is true iff multicast *)
+  | SGen of gen_type * exp (* Bool is true iff multicast *)
   | SSeq of statement * statement
   | SMatch of exp list * branch list
   | SRet of exp option

--- a/src/lib/midend/CoreSyntax.ml
+++ b/src/lib/midend/CoreSyntax.ml
@@ -98,6 +98,7 @@ and e =
   | EOp of op * exp list
   | ECall of cid * exp list
   | EHash of size * exp list
+  | EGroup of exp list
   | EFlood of exp
 
 and exp =
@@ -146,7 +147,6 @@ and d =
   | DEvent of id * event_sort * params
   | DHandler of id * body
   | DMemop of id * body
-  | DGroup of id * exp list
   | DExtern of id * ty
 
 (* name, return type, args & body *)
@@ -253,7 +253,6 @@ let dglobal_sp id ty exp span = decl_sp (DGlobal (id, ty, exp)) span
 let dextern_sp id ty span = decl_sp (DExtern (id, ty)) span
 let handler_sp id p body span = decl_sp (DHandler (id, (p, body))) span
 let memop_sp id p body span = decl_sp (DMemop (id, (p, body))) span
-let group_sp id es span = decl_sp (DGroup (id, es)) span
 
 (*** Utility -- may split into a separate file if it gets big *)
 

--- a/src/lib/midend/CoreSyntax.ml
+++ b/src/lib/midend/CoreSyntax.ml
@@ -12,7 +12,7 @@ and z = [%import: (Z.t[@opaque])]
 
 and zint = [%import: (Integer.t[@with Z.t := (Z.t [@opaque])])]
 
-and location = zint
+and location = int
 
 (* All sizes should be inlined and precomputed *)
 and size = int
@@ -98,6 +98,7 @@ and e =
   | EOp of op * exp list
   | ECall of cid * exp list
   | EHash of size * exp list
+  | EFlood of exp
 
 and exp =
   { e : e

--- a/src/lib/midend/MidendPipeline.ml
+++ b/src/lib/midend/MidendPipeline.ml
@@ -17,14 +17,13 @@ let process_prog ?(for_interp = false) ds =
   let ds = SyntaxToCore.translate_prog ds in
   LogIr.log_lucid "midend_start.dpt" ds;
   print_if_debug ds;
-  print_if_verbose "-------Partial interpreting---------";
-  
-  print_if_debug ds;
   (* The rest of these transformations aren't necessary for the interpreter *)
   match for_interp with
-  | true -> 
+  | true ->
     (* partial interpretation is causing execution tests to fail in P4. *)
+    print_if_verbose "-------Partial interpreting---------";
     let ds = PartialInterpretation.interp_prog ds in
+    print_if_debug ds;
     ds
   | false ->
     print_if_verbose "-------Eliminating range relational ops--------";
@@ -32,7 +31,6 @@ let process_prog ?(for_interp = false) ds =
     (* temporary patches for incomplete features. *)
     let ds = PoplPatches.eliminate_noncall_units ds in
     let ds = PoplPatches.delete_prints ds in
-
     print_if_verbose "-------Adding default branches--------";
     let ds = AddDefaultBranches.add_default_branches ds in
     print_if_debug ds;

--- a/src/lib/midend/MidendPipeline.ml
+++ b/src/lib/midend/MidendPipeline.ml
@@ -15,7 +15,6 @@ let do_ssa = false
 let process_prog ?(for_interp = false) ds =
   print_if_verbose "-------Translating to core syntax---------";
   let ds = SyntaxToCore.translate_prog ds in
-  LogIr.log_lucid "midend_start.dpt" ds;
   print_if_debug ds;
   (* The rest of these transformations aren't necessary for the interpreter *)
   match for_interp with
@@ -26,6 +25,7 @@ let process_prog ?(for_interp = false) ds =
     print_if_debug ds;
     ds
   | false ->
+    LogIr.log_lucid "midend_start.dpt" ds;
     print_if_verbose "-------Eliminating range relational ops--------";
     let ds = EliminateEqRangeOps.transform ds in
     (* temporary patches for incomplete features. *)

--- a/src/lib/midend/interpreter/Interp.ml
+++ b/src/lib/midend/interpreter/Interp.ml
@@ -18,10 +18,10 @@ let initial_state (pp : Preprocess.t) (spec : InterpSpec.t) =
     (fun i exs -> Env.iter (fun cid v -> State.add_global i cid (V v) nst) exs)
     spec.externs;
   List.iter
-    (fun event ->
+    (fun (event, locs) ->
       List.iter
         (fun loc -> State.push_input_event (Integer.to_int loc) event nst)
-        event.elocations)
+        locs)
     spec.events;
   nst
 ;;

--- a/src/lib/midend/interpreter/Interp.ml
+++ b/src/lib/midend/interpreter/Interp.ml
@@ -21,8 +21,7 @@ let initial_state (pp : Preprocess.t) (spec : InterpSpec.t) =
   List.iter
     (fun (event, locs) ->
       List.iter
-        (fun (loc, port) ->
-          State.push_input_event (Integer.to_int loc) port event nst)
+        (fun (loc, port) -> State.push_input_event loc port event nst)
         locs)
     spec.events;
   nst

--- a/src/lib/midend/interpreter/InterpCore.ml
+++ b/src/lib/midend/interpreter/InterpCore.ml
@@ -223,18 +223,23 @@ let rec interp_statement nst swid locals s =
     if !(nst.switches.(swid).retval) <> None
     then locals
     else interp_statement nst swid locals ss2
-  | SGen (_, e) ->
-    let event = interp_exp e |> extract_ival |> raw_event in
-    if Env.find event.eid nst.event_sorts = EExit
-    then State.log_exit swid event nst
-    else (
-      let locs =
-        if List.length event.elocations = 0
-        then [swid]
-        else List.map Integer.to_int event.elocations
-      in
-      List.iter (fun loc -> State.push_event loc event nst) locs);
-    locals
+  | SGen (g, e) ->
+    begin
+      match g with
+      | GSingle | GMulti ->
+        let event = interp_exp e |> extract_ival |> raw_event in
+        if Env.find event.eid nst.event_sorts = EExit
+        then State.log_exit swid event nst
+        else (
+          let locs =
+            if List.length event.elocations = 0
+            then [swid]
+            else List.map Integer.to_int event.elocations
+          in
+          List.iter (fun loc -> State.push_event loc event nst) locs);
+        locals
+      | _ -> failwith "NYI"
+    end
   | SRet (Some e) ->
     let v = interp_exp e |> extract_ival in
     (* Computation stops if retval is Some *)

--- a/src/lib/midend/interpreter/InterpCore.ml
+++ b/src/lib/midend/interpreter/InterpCore.ml
@@ -146,17 +146,6 @@ let rec interp_exp (nst : State.network_state) swid locals e : State.ival =
       let hashed = Legacy.Hashtbl.seeded_hash (Integer.to_int seed) tl in
       V (vint hashed size)
     | _ -> failwith "Wrong arguments to hash operation")
-  | EGroup es ->
-    let ports =
-      List.map
-        (fun e ->
-          interp_exp nst swid locals e
-          |> extract_ival
-          |> raw_integer
-          |> Integer.to_int)
-        es
-    in
-    V (vgroup ports)
   | EFlood e1 ->
     let port =
       interp_exp nst swid locals e1

--- a/src/lib/midend/interpreter/InterpCore.ml
+++ b/src/lib/midend/interpreter/InterpCore.ml
@@ -233,11 +233,14 @@ let rec interp_statement nst swid locals s =
     (* TODO: Right now, port numbers for generate_single and generate_multi are
        arbitrary (always 0). We could do better by e.g. finding a path through
        the graph and figuring out which port number it ends at *)
-    (* FIXME: Figure out where recirc_port should really be defined *)
-    let recirc_port = 196 in
     let locs =
       match g with
-      | GSingle None -> [swid, recirc_port]
+      | GSingle None ->
+        [ ( swid
+          , State.lookup swid (Cid.from_string "recirculation_port") nst
+            |> extract_ival
+            |> raw_integer
+            |> Integer.to_int ) ]
       | GSingle (Some e) ->
         [interp_exp e |> extract_ival |> raw_integer |> Integer.to_int, 0]
       | GMulti grp ->

--- a/src/lib/midend/interpreter/InterpCore.ml
+++ b/src/lib/midend/interpreter/InterpCore.ml
@@ -261,7 +261,7 @@ let rec interp_statement nst swid locals s =
       List.iter
         (fun (dst_id, port) ->
           if dst_id = -1 (* lookup_dst failed *)
-          then State.log_exit dst_id (Some port) event nst
+          then State.log_exit swid (Some port) event nst
           else State.push_event dst_id port event nst)
         locs;
     locals

--- a/src/lib/midend/interpreter/InterpSpec.ml
+++ b/src/lib/midend/interpreter/InterpSpec.ml
@@ -36,10 +36,7 @@ let rec parse_value err_str ty j =
   | `Int n, TInt size -> vint n size
   | `Bool b, TBool -> vbool b
   | `List lst, TGroup ->
-    vgroup
-      (List.map
-         (fun n -> Integer.of_int @@ parse_int "group value definition" n)
-         lst)
+    vgroup (List.map (fun n -> parse_int "group value definition" n) lst)
   | _ ->
     error
     @@ err_str

--- a/src/lib/midend/interpreter/InterpSpec.ml
+++ b/src/lib/midend/interpreter/InterpSpec.ml
@@ -241,13 +241,22 @@ let parse (pp : Preprocess.t) (renaming : Renaming.env) (filename : string) : t 
       | _ -> error "No value or non-int value specified for max time"
     in
     let externs =
-      let lst =
+      let externs =
         match List.assoc_opt "externs" lst with
         | Some (`Assoc lst) -> lst
         | None -> []
         | Some _ -> error "Non-assoc type for extern definitions"
       in
-      parse_externs pp renaming num_switches lst
+      let recirc_ports =
+        (* This is an extern under the hood, but users don't see it that way *)
+        match List.assoc_opt "recirculation_ports" lst with
+        | Some (`List lst) -> "recirculation_port", `List lst
+        | None ->
+          ( "recirculation_port"
+          , `List (List.init num_switches (fun _ -> `Int 196)) )
+        | Some _ -> error "Non-list type for recirculation port definitions"
+      in
+      parse_externs pp renaming num_switches (recirc_ports :: externs)
     in
     let events =
       match List.assoc_opt "events" lst with

--- a/src/lib/midend/interpreter/InterpSpec.ml
+++ b/src/lib/midend/interpreter/InterpSpec.ml
@@ -7,7 +7,7 @@ module Env = InterpState.Env
 type t =
   { num_switches : int
   ; externs : value Env.t list
-  ; events : event list
+  ; events : (event * location list) list
   ; config : InterpState.State.config
   }
 
@@ -90,7 +90,7 @@ let parse_events
           !last_delay
         | _ -> error "Event specification had non-integer delay field"
       in
-      let elocations =
+      let locations =
         match List.assoc_opt "locations" lst with
         | Some (`List lst) ->
           List.map
@@ -107,7 +107,7 @@ let parse_events
         | None -> [Integer.create 0 32]
         | _ -> error "Event specification has non-list locations field"
       in
-      { eid; data; edelay; elocations }
+      { eid; data; edelay }, locations
     | _ -> error "Non-assoc type for event definition"
   in
   List.map parse_event events

--- a/src/lib/midend/interpreter/InterpState.ml
+++ b/src/lib/midend/interpreter/InterpState.ml
@@ -2,12 +2,13 @@
 open CoreSyntax
 open Batteries
 module Env = Collections.CidMap
+module IntMap = Map.Make (Int)
 
 module State = struct
   module EventQueue = BatHeap.Make (struct
-    type t = int * event
+    type t = int * event * int
 
-    let compare t1 t2 = Pervasives.compare (fst t1) (fst t2)
+    let compare (t1, _, _) (t2, _, _) = Pervasives.compare t1 t2
   end)
 
   type stats_counter =
@@ -16,6 +17,15 @@ module State = struct
     }
 
   let empty_counter = { entries_handled = 0; total_handled = 0 }
+
+  type topology = (int * int) IntMap.t IntMap.t
+
+  let empty_topology num_switches =
+    List.fold_left
+      (fun acc n -> IntMap.add n IntMap.empty acc)
+      IntMap.empty
+      (List.init num_switches (fun n -> n))
+  ;;
 
   type config =
     { max_time : int
@@ -31,6 +41,7 @@ module State = struct
     ; config : config
     ; event_sorts : event_sort Env.t
     ; handlers : handler Env.t
+    ; links : topology
     ; switches : state array
     }
 
@@ -38,7 +49,7 @@ module State = struct
     { global_env : ival Env.t
     ; event_queue : EventQueue.t
     ; pipeline : Pipeline.t
-    ; exits : (event * int) Queue.t
+    ; exits : (event * int option * int) Queue.t
     ; retval : value option ref
     ; counter : stats_counter ref
     }
@@ -47,9 +58,10 @@ module State = struct
     | V of value
     | F of code
 
-  and code = network_state -> int -> ival list -> value
+  and code = network_state -> int (* switch *) -> ival list -> value
 
-  and handler = network_state -> int -> event -> unit
+  and handler =
+    network_state -> int (* switch *) -> int (* port *) -> event -> unit
 
   type global_fun =
     { cid : Cid.t
@@ -71,6 +83,7 @@ module State = struct
     ; event_sorts = Env.empty
     ; handlers = Env.empty
     ; switches = Array.of_list []
+    ; links = empty_topology 0
     }
   ;;
 
@@ -119,8 +132,8 @@ module State = struct
     { nst with handlers = Env.add cid lam nst.handlers }
   ;;
 
-  let log_exit swid event nst =
-    Queue.push (event, nst.current_time) nst.switches.(swid).exits
+  let log_exit swid port event nst =
+    Queue.push (event, port, nst.current_time) nst.switches.(swid).exits
   ;;
 
   let update_counter swid event nst =
@@ -137,21 +150,23 @@ module State = struct
     st.counter := new_counter
   ;;
 
-  let push_event swid event nst =
+  let push_event swid port event nst =
     let st = nst.switches.(swid) in
     let t =
       nst.current_time
       + max event.edelay nst.config.generate_delay
       + Random.int nst.config.random_delay_range
     in
-    let event_queue = EventQueue.add (t, event) st.event_queue in
+    let event_queue = EventQueue.add (t, event, port) st.event_queue in
     nst.switches.(swid) <- { st with event_queue }
   ;;
 
   (* Like push_event, but doesn't add any artificial delays *)
-  let push_input_event swid event nst =
+  let push_input_event swid port event nst =
     let st = nst.switches.(swid) in
-    let event_queue = EventQueue.add (event.edelay, event) st.event_queue in
+    let event_queue =
+      EventQueue.add (event.edelay, event, port) st.event_queue
+    in
     nst.switches.(swid) <- { st with event_queue }
   ;;
 
@@ -160,13 +175,13 @@ module State = struct
     if EventQueue.size q = 0
     then None
     else (
-      let t, event = EventQueue.find_min q in
+      let t, event, port = EventQueue.find_min q in
       if t > nst.current_time
       then None
       else (
         nst.switches.(swid)
           <- { (nst.switches.(swid)) with event_queue = EventQueue.del_min q };
-        Some event))
+        Some (event, port)))
   ;;
 
   let next_time_st st =
@@ -174,7 +189,7 @@ module State = struct
     if EventQueue.size q = 0
     then None
     else (
-      let t, _ = EventQueue.find_min q in
+      let t, _, _ = EventQueue.find_min q in
       Some t)
   ;;
 
@@ -190,6 +205,16 @@ module State = struct
 
   let update_switch swid stage idx getop setop nst =
     Pipeline.update ~stage ~idx ~getop ~setop nst.switches.(swid).pipeline
+  ;;
+
+  (* Maps switch * port -> switch * port according to the topology *)
+  let lookup_dst nst (sw, p) =
+    match IntMap.find_opt sw nst.links with
+    | Some map ->
+      (match IntMap.find_opt p map with
+      | None -> -1, p
+      | Some ret -> ret)
+    | None -> error @@ "Invalid switch id " ^ string_of_int sw
   ;;
 
   let ival_to_string v =
@@ -219,12 +244,13 @@ module State = struct
       @@ (q
          |> EventQueue.to_list (* No BatHeap.fold :( *)
          |> List.fold_left
-              (fun acc (t, event) ->
+              (fun acc (t, event, port) ->
                 Printf.sprintf
-                  "%s    %dns: %s\n"
+                  "%s    %dns: %s at port %d\n"
                   acc
                   t
-                  (CorePrinting.event_to_string event))
+                  (CorePrinting.event_to_string event)
+                  port)
               "")
   ;;
 
@@ -234,13 +260,13 @@ module State = struct
     else
       Printf.sprintf "[\n%s  ]"
       @@ Queue.fold
-           (fun acc (event, time) ->
-             acc
-             ^ "    "
-             ^ CorePrinting.event_to_string event
-             ^ " at t="
-             ^ string_of_int time
-             ^ "\n")
+           (fun acc (event, port, time) ->
+             Printf.sprintf
+               "%s    %s at port %d, t=%d\n"
+               acc
+               (CorePrinting.event_to_string event)
+               (Option.default (-1) port)
+               time)
            ""
            s
   ;;

--- a/src/lib/midend/interpreter/InterpState.ml
+++ b/src/lib/midend/interpreter/InterpState.ml
@@ -18,6 +18,7 @@ module State = struct
 
   let empty_counter = { entries_handled = 0; total_handled = 0 }
 
+  (* Maps switch -> port -> (switch * port) *)
   type topology = (int * int) IntMap.t IntMap.t
 
   let empty_topology num_switches =

--- a/src/lib/midend/interpreter/Preprocess.ml
+++ b/src/lib/midend/interpreter/Preprocess.ml
@@ -8,7 +8,14 @@ type t =
   ; externs : ty Env.t
   }
 
-let empty = { events = Env.empty; externs = Env.empty }
+let empty =
+  { events = Env.empty
+  ; externs =
+      Env.singleton
+        (Id Builtins.recirc_id)
+        (SyntaxToCore.translate_ty Builtins.recirc_ty)
+  }
+;;
 
 (* Remove and process declarations which we can/must do beforehand --
    extern/event declarations, and precompute size values *)

--- a/src/lib/midend/transformations/InterpHelpers.ml
+++ b/src/lib/midend/transformations/InterpHelpers.ml
@@ -191,6 +191,8 @@ let is_atomic exp =
   (* calls are atomic if they have all immediate args *)
   | EHash (_, args) | ECall (_, args) ->
     CL.map is_immediate args |> CL.for_all identity
+  (* a flood expression is atomic if its argument is an immediate *)
+  | EFlood(arg) -> is_immediate arg 
 ;;
 
 let is_bool_non_immediate exp = is_bool exp && not (is_immediate exp)

--- a/src/lib/midend/transformations/PartialInterpretation.ml
+++ b/src/lib/midend/transformations/PartialInterpretation.ml
@@ -116,7 +116,6 @@ let rec interp_exp env e =
     { e with e = ECall (cid, List.map (interp_exp env) args) }
   | EHash (sz, args) ->
     { e with e = EHash (sz, List.map (interp_exp env) args) }
-  | EGroup es -> { e with e = EGroup (List.map (interp_exp env) es) }
   | EFlood e' -> { e with e = EFlood (interp_exp env e') }
   | EOp (op, args) -> { e with e = interp_op env op args }
 

--- a/src/lib/midend/transformations/PartialInterpretation.ml
+++ b/src/lib/midend/transformations/PartialInterpretation.ml
@@ -116,6 +116,7 @@ let rec interp_exp env e =
     { e with e = ECall (cid, List.map (interp_exp env) args) }
   | EHash (sz, args) ->
     { e with e = EHash (sz, List.map (interp_exp env) args) }
+  | EGroup es -> { e with e = EGroup (List.map (interp_exp env) es) }
   | EFlood e' -> { e with e = EFlood (interp_exp env e') }
   | EOp (op, args) -> { e with e = interp_op env op args }
 
@@ -381,9 +382,6 @@ let interp_decl env d =
     let e = interp_exp env e in
     let env = add_dec env id in
     env, { d with d = DGlobal (id, ty, e) }
-  | DGroup (id, exps) ->
-    let env = add_dec env id in
-    env, { d with d = DGroup (id, List.map (interp_exp env) exps) }
   | DMemop (id, body) ->
     let env = add_dec env id in
     env, { d with d = DMemop (id, interp_body env body) }

--- a/src/lib/midend/transformations/PartialInterpretation.ml
+++ b/src/lib/midend/transformations/PartialInterpretation.ml
@@ -116,6 +116,7 @@ let rec interp_exp env e =
     { e with e = ECall (cid, List.map (interp_exp env) args) }
   | EHash (sz, args) ->
     { e with e = EHash (sz, List.map (interp_exp env) args) }
+  | EFlood e' -> { e with e = EFlood (interp_exp env e') }
   | EOp (op, args) -> { e with e = interp_op env op args }
 
 (* Mostly copied from InterpCore, could maybe merge the two functions *)

--- a/src/lib/midend/transformations/SyntaxToCore.ml
+++ b/src/lib/midend/transformations/SyntaxToCore.ml
@@ -73,7 +73,7 @@ let rec translate_value (v : S.value) : C.value =
     | S.VBool b -> C.VBool b
     | S.VInt z -> C.VInt z
     | S.VGlobal n -> C.VGlobal n
-    | S.VGroup ls -> C.VGroup ls
+    | S.VGroup ls -> C.VGroup (List.map Integer.to_int ls)
     | VEvent { eid; data; edelay } ->
       C.VEvent { eid; data = List.map translate_value data; edelay }
   in
@@ -91,6 +91,7 @@ let rec translate_exp (e : S.exp) : C.exp =
     | S.EOp (op, es) -> C.EOp (translate_op op, List.map translate_exp es)
     | S.ECall (cid, es) -> C.ECall (cid, List.map translate_exp es)
     | S.EHash (sz, es) -> C.EHash (translate_size sz, List.map translate_exp es)
+    | S.EFlood e -> C.EFlood (translate_exp e)
     | _ -> err e.espan (Printing.exp_to_string e)
   in
   { e = e'; ety = translate_ty (Option.get e.ety); espan = e.espan }

--- a/src/lib/midend/transformations/SyntaxToCore.ml
+++ b/src/lib/midend/transformations/SyntaxToCore.ml
@@ -73,7 +73,7 @@ let rec translate_value (v : S.value) : C.value =
     | S.VBool b -> C.VBool b
     | S.VInt z -> C.VInt z
     | S.VGlobal n -> C.VGlobal n
-    | S.VGroup ls -> C.VGroup (List.map Integer.to_int ls)
+    | S.VGroup ls -> C.VGroup ls
     | VEvent { eid; data; edelay } ->
       C.VEvent { eid; data = List.map translate_value data; edelay }
   in
@@ -91,7 +91,6 @@ let rec translate_exp (e : S.exp) : C.exp =
     | S.EOp (op, es) -> C.EOp (translate_op op, List.map translate_exp es)
     | S.ECall (cid, es) -> C.ECall (cid, List.map translate_exp es)
     | S.EHash (sz, es) -> C.EHash (translate_size sz, List.map translate_exp es)
-    | S.EGroup es -> C.EGroup (List.map translate_exp es)
     | S.EFlood e -> C.EFlood (translate_exp e)
     | _ -> err e.espan (Printing.exp_to_string e)
   in

--- a/src/lib/midend/transformations/SyntaxToCore.ml
+++ b/src/lib/midend/transformations/SyntaxToCore.ml
@@ -96,6 +96,12 @@ let rec translate_exp (e : S.exp) : C.exp =
   { e = e'; ety = translate_ty (Option.get e.ety); espan = e.espan }
 ;;
 
+let translate_gen_type = function
+  | S.GSingle -> C.GSingle
+  | S.GMulti -> C.GMulti
+  | S.GPort e -> C.GPort (translate_exp e)
+;;
+
 let rec translate_statement (s : S.statement) : C.statement =
   (* (match s.s with
   | SSeq _ | SNoop -> ()
@@ -112,7 +118,7 @@ let rec translate_statement (s : S.statement) : C.statement =
     | S.SPrintf (str, es) -> C.SPrintf (str, List.map translate_exp es)
     | S.SIf (e, s1, s2) ->
       C.SIf (translate_exp e, translate_statement s1, translate_statement s2)
-    | S.SGen (b, e) -> C.SGen (b, translate_exp e)
+    | S.SGen (g, e) -> C.SGen (translate_gen_type g, translate_exp e)
     | S.SSeq (s1, s2) -> C.SSeq (translate_statement s1, translate_statement s2)
     | S.SMatch (es, branches) ->
       C.SMatch (List.map translate_exp es, List.map translate_branch branches)

--- a/src/lib/midend/transformations/SyntaxToCore.ml
+++ b/src/lib/midend/transformations/SyntaxToCore.ml
@@ -18,8 +18,8 @@ let rec translate_ty (ty : S.ty) : C.ty =
     match S.TyTQVar.strip_links ty.raw_ty with
     | S.TBool -> C.TBool
     | S.TGroup -> C.TGroup
+    | S.TEvent -> C.TEvent
     | S.TInt sz -> C.TInt (translate_size sz)
-    | S.TEvent b -> C.TEvent b
     | S.TName (cid, sizes, b) -> C.TName (cid, List.map translate_size sizes, b)
     | S.TMemop (sz1, sz2) -> C.TMemop (translate_size sz1, translate_size sz2)
     | S.TFun fty ->
@@ -74,8 +74,8 @@ let rec translate_value (v : S.value) : C.value =
     | S.VInt z -> C.VInt z
     | S.VGlobal n -> C.VGlobal n
     | S.VGroup ls -> C.VGroup ls
-    | VEvent { eid; data; edelay; elocations } ->
-      C.VEvent { eid; data = List.map translate_value data; edelay; elocations }
+    | VEvent { eid; data; edelay } ->
+      C.VEvent { eid; data = List.map translate_value data; edelay }
   in
   { v = v'; vty = translate_ty (Option.get v.vty); vspan = v.vspan }
 ;;
@@ -97,8 +97,8 @@ let rec translate_exp (e : S.exp) : C.exp =
 ;;
 
 let translate_gen_type = function
-  | S.GSingle -> C.GSingle
-  | S.GMulti -> C.GMulti
+  | S.GSingle eo -> C.GSingle (Option.map translate_exp eo)
+  | S.GMulti e -> C.GMulti (translate_exp e)
   | S.GPort e -> C.GPort (translate_exp e)
 ;;
 

--- a/src/lib/midend/transformations/SyntaxToCore.ml
+++ b/src/lib/midend/transformations/SyntaxToCore.ml
@@ -91,6 +91,7 @@ let rec translate_exp (e : S.exp) : C.exp =
     | S.EOp (op, es) -> C.EOp (translate_op op, List.map translate_exp es)
     | S.ECall (cid, es) -> C.ECall (cid, List.map translate_exp es)
     | S.EHash (sz, es) -> C.EHash (translate_size sz, List.map translate_exp es)
+    | S.EGroup es -> C.EGroup (List.map translate_exp es)
     | S.EFlood e -> C.EFlood (translate_exp e)
     | _ -> err e.espan (Printing.exp_to_string e)
   in
@@ -152,7 +153,6 @@ let translate_decl (d : S.decl) : C.decl =
       C.DEvent (id, translate_sort sort, translate_params params)
     | S.DHandler (id, body) -> C.DHandler (id, translate_body body)
     | S.DMemop (id, body) -> C.DMemop (id, translate_body body)
-    | S.DGroup (id, es) -> C.DGroup (id, List.map translate_exp es)
     | S.DExtern (id, ty) -> C.DExtern (id, translate_ty ty)
     | _ -> err d.dspan (Printing.decl_to_string d)
   in

--- a/src/lib/midend/transformations/normalizeBools.ml
+++ b/src/lib/midend/transformations/normalizeBools.ml
@@ -265,6 +265,10 @@ module NormalizeBoolExps = struct
       error
         "z3_from_expr got an ehash -- this should have been eliminated by an \
          earlier pass."
+    | (EFlood _, _) -> 
+      error
+        "z3_from_expr got an eflood -- there shouldn't be a flood constructor \
+        inside of a boolean"
   ;;
 
   (* tell Z3 to convert a boolean expression into disjunctive normal form *)

--- a/test/expected/BloomFilter_output.txt
+++ b/test/expected/BloomFilter_output.txt
@@ -3,16 +3,16 @@ dpt: Auto-detected specification file examples/interp_tests/BloomFilter.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling entry event in(false,3) at switch 0
-t=10000: Handling entry event in(true,3) at switch 0
-t=20000: Handling entry event in(false,3) at switch 0
-t=30000: Handling entry event in(true,7) at switch 0
-t=40000: Handling entry event in(true,8) at switch 0
-t=50000: Handling entry event in(false,3) at switch 0
-t=60000: Handling entry event in(false,7) at switch 0
-t=70000: Handling entry event in(false,8) at switch 0
-t=80000: Handling entry event in(false,9) at switch 0
-t=90000: Handling entry event in(false,10) at switch 0
+t=0: Handling entry event in(false,3) at switch 0, port 0
+t=10000: Handling entry event in(true,3) at switch 0, port 0
+t=20000: Handling entry event in(false,3) at switch 0, port 0
+t=30000: Handling entry event in(true,7) at switch 0, port 0
+t=40000: Handling entry event in(true,8) at switch 0, port 0
+t=50000: Handling entry event in(false,3) at switch 0, port 0
+t=60000: Handling entry event in(false,7) at switch 0, port 0
+t=70000: Handling entry event in(false,8) at switch 0, port 0
+t=80000: Handling entry event in(false,9) at switch 0, port 0
+t=90000: Handling entry event in(false,10) at switch 0, port 0
 dpt: Final State:
 
 Switch 0 : {
@@ -27,13 +27,13 @@ Switch 0 : {
  Events :   [ ]
 
  Exits :    [
-    denied(3) at t=0
-    allowed(3) at t=20000
-    allowed(3) at t=50000
-    allowed(7) at t=60000
-    allowed(8) at t=70000
-    denied(9) at t=80000
-    denied(10) at t=90000
+    denied(3) at port -1, t=0
+    allowed(3) at port -1, t=20000
+    allowed(3) at port -1, t=50000
+    allowed(7) at port -1, t=60000
+    allowed(8) at port -1, t=70000
+    denied(9) at port -1, t=80000
+    denied(10) at port -1, t=90000
   ]
 
  entry events handled: 10

--- a/test/expected/NAT_output.txt
+++ b/test/expected/NAT_output.txt
@@ -3,41 +3,41 @@ dpt: Auto-detected specification file examples/interp_tests/NAT.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling entry event outside_packet(10) at switch 0
+t=0: Handling entry event outside_packet(10) at switch 0, port 0
 Mapped port 10 to (ip: 0, port: 0)
 dropped
-t=100000: Handling entry event outside_packet(12) at switch 0
+t=100000: Handling entry event outside_packet(12) at switch 0, port 0
 Mapped port 12 to (ip: 0, port: 0)
 dropped
-t=200000: Handling entry event outside_packet(14) at switch 0
+t=200000: Handling entry event outside_packet(14) at switch 0, port 0
 Mapped port 14 to (ip: 0, port: 0)
 dropped
-t=300000: Handling entry event inside_packet(10,100) at switch 0
+t=300000: Handling entry event inside_packet(10,100) at switch 0, port 0
 Adding to NAT
-t=300600: Handling event add_to_nat(10,100) at switch 0
+t=300600: Handling event add_to_nat(10,100) at switch 0, port 196
 Mapped (ip: 10, port: 100) to port 11
-t=400000: Handling entry event inside_packet(10,100) at switch 0
+t=400000: Handling entry event inside_packet(10,100) at switch 0, port 0
 IP already in NAT, maps to port 11
-t=500000: Handling entry event outside_packet(10) at switch 0
+t=500000: Handling entry event outside_packet(10) at switch 0, port 0
 Mapped port 10 to (ip: 0, port: 0)
 dropped
-t=600000: Handling entry event outside_packet(12) at switch 0
+t=600000: Handling entry event outside_packet(12) at switch 0, port 0
 Mapped port 12 to (ip: 0, port: 0)
 dropped
-t=700000: Handling entry event outside_packet(14) at switch 0
+t=700000: Handling entry event outside_packet(14) at switch 0, port 0
 Mapped port 14 to (ip: 0, port: 0)
 dropped
-t=800000: Handling entry event inside_packet(11,101) at switch 0
+t=800000: Handling entry event inside_packet(11,101) at switch 0, port 0
 Adding to NAT
-t=800600: Handling event add_to_nat(11,101) at switch 0
+t=800600: Handling event add_to_nat(11,101) at switch 0, port 196
 Mapped (ip: 11, port: 101) to port 14
-t=900000: Handling entry event outside_packet(10) at switch 0
+t=900000: Handling entry event outside_packet(10) at switch 0, port 0
 Mapped port 10 to (ip: 0, port: 0)
 dropped
-t=1000000: Handling entry event outside_packet(12) at switch 0
+t=1000000: Handling entry event outside_packet(12) at switch 0, port 0
 Mapped port 12 to (ip: 0, port: 0)
 dropped
-t=1100000: Handling entry event outside_packet(14) at switch 0
+t=1100000: Handling entry event outside_packet(14) at switch 0, port 0
 Mapped port 14 to (ip: 11, port: 101)
 dpt: Final State:
 
@@ -51,10 +51,10 @@ Switch 0 : {
  Events :   [ ]
 
  Exits :    [
-    inside_continue(11) at t=300600
-    inside_continue(11) at t=400000
-    inside_continue(14) at t=800600
-    outside_continue(11,101) at t=1100000
+    inside_continue(11) at port -1, t=300600
+    inside_continue(11) at port -1, t=400000
+    inside_continue(14) at port -1, t=800600
+    outside_continue(11,101) at port -1, t=1100000
   ]
 
  entry events handled: 12

--- a/test/expected/NAT_output.txt
+++ b/test/expected/NAT_output.txt
@@ -1,12 +1,4 @@
 dpt: Parsing ...
-
-In examples/interp_tests/NAT.dpt: 
-
-53|    generate add_to_nat(src_ip, src_port); // Will generate the continue for us
-                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-warning: examples/interp_tests/NAT.dpt: Conditional generation of potential non-exit event in entry handler.
-
 dpt: Auto-detected specification file examples/interp_tests/NAT.json
 dpt: Simulating...
 dpt: Using random seed: 0

--- a/test/expected/basics_output.txt
+++ b/test/expected/basics_output.txt
@@ -62,8 +62,8 @@ t=16600: Handling event count_to_10(10) at switch 0, port 196
 t=17200: Handling event count_to_10(11) at switch 0, port 196
 got to 10
 t=20000: Handling entry event packetin(12,102) at switch 0, port 0
-t=20000: Handling entry event packetin(12,102) at switch 1, port 0
-t=20000: Handling entry event packetin(12,102) at switch 2, port 0
+t=20000: Handling entry event packetin(12,102) at switch 1, port 7
+t=20000: Handling entry event packetin(12,102) at switch 2, port 1
 t=20600: Handling event count_to_10(0) at switch 0, port 196
 at 0
 t=20600: Handling event count_to_10(0) at switch 1, port 196
@@ -137,8 +137,8 @@ got to 10
 t=27200: Handling event count_to_10(11) at switch 2, port 196
 got to 10
 t=40000: Handling entry event packetin(13,103) at switch 0, port 0
-t=40007: Handling entry event packetin(14,104) at switch 0, port 0
-t=40007: Handling entry event packetin(14,104) at switch 1, port 0
+t=40007: Handling entry event packetin(14,104) at switch 0, port 3
+t=40007: Handling entry event packetin(14,104) at switch 1, port 19
 t=40600: Handling event count_to_10(0) at switch 0, port 196
 at 0
 t=40607: Handling event count_to_10(0) at switch 0, port 196

--- a/test/expected/basics_output.txt
+++ b/test/expected/basics_output.txt
@@ -12,202 +12,202 @@ dpt: Simulating...
 dpt: Using random seed: 0
 
 t=0: Handling entry event packetin(10,100) at switch 0, port 0
-t=600: Handling event count_to_10(0) at switch 0, port 196
+t=600: Handling event count_to_10(0) at switch 0, port 255
 at 0
-t=1200: Handling event count_to_10(1) at switch 0, port 196
+t=1200: Handling event count_to_10(1) at switch 0, port 255
 1
-t=1800: Handling event count_to_10(2) at switch 0, port 196
+t=1800: Handling event count_to_10(2) at switch 0, port 255
 2
-t=2400: Handling event count_to_10(3) at switch 0, port 196
+t=2400: Handling event count_to_10(3) at switch 0, port 255
 3
-t=3000: Handling event count_to_10(4) at switch 0, port 196
+t=3000: Handling event count_to_10(4) at switch 0, port 255
 4
-t=3600: Handling event count_to_10(5) at switch 0, port 196
+t=3600: Handling event count_to_10(5) at switch 0, port 255
 5
-t=4200: Handling event count_to_10(6) at switch 0, port 196
+t=4200: Handling event count_to_10(6) at switch 0, port 255
 6
-t=4800: Handling event count_to_10(7) at switch 0, port 196
+t=4800: Handling event count_to_10(7) at switch 0, port 255
 7
-t=5400: Handling event count_to_10(8) at switch 0, port 196
+t=5400: Handling event count_to_10(8) at switch 0, port 255
 8
-t=6000: Handling event count_to_10(9) at switch 0, port 196
+t=6000: Handling event count_to_10(9) at switch 0, port 255
 9
-t=6600: Handling event count_to_10(10) at switch 0, port 196
+t=6600: Handling event count_to_10(10) at switch 0, port 255
 10
-t=7200: Handling event count_to_10(11) at switch 0, port 196
+t=7200: Handling event count_to_10(11) at switch 0, port 255
 got to 10
 t=10000: Handling entry event packetin(11,101) at switch 0, port 0
-t=10600: Handling event count_to_10(0) at switch 0, port 196
+t=10600: Handling event count_to_10(0) at switch 0, port 255
 at 0
-t=11200: Handling event count_to_10(1) at switch 0, port 196
+t=11200: Handling event count_to_10(1) at switch 0, port 255
 1
-t=11800: Handling event count_to_10(2) at switch 0, port 196
+t=11800: Handling event count_to_10(2) at switch 0, port 255
 2
-t=12400: Handling event count_to_10(3) at switch 0, port 196
+t=12400: Handling event count_to_10(3) at switch 0, port 255
 3
-t=13000: Handling event count_to_10(4) at switch 0, port 196
+t=13000: Handling event count_to_10(4) at switch 0, port 255
 4
-t=13600: Handling event count_to_10(5) at switch 0, port 196
+t=13600: Handling event count_to_10(5) at switch 0, port 255
 5
-t=14200: Handling event count_to_10(6) at switch 0, port 196
+t=14200: Handling event count_to_10(6) at switch 0, port 255
 6
-t=14800: Handling event count_to_10(7) at switch 0, port 196
+t=14800: Handling event count_to_10(7) at switch 0, port 255
 7
-t=15400: Handling event count_to_10(8) at switch 0, port 196
+t=15400: Handling event count_to_10(8) at switch 0, port 255
 8
-t=16000: Handling event count_to_10(9) at switch 0, port 196
+t=16000: Handling event count_to_10(9) at switch 0, port 255
 9
-t=16600: Handling event count_to_10(10) at switch 0, port 196
+t=16600: Handling event count_to_10(10) at switch 0, port 255
 10
-t=17200: Handling event count_to_10(11) at switch 0, port 196
+t=17200: Handling event count_to_10(11) at switch 0, port 255
 got to 10
 t=20000: Handling entry event packetin(12,102) at switch 0, port 0
 t=20000: Handling entry event packetin(12,102) at switch 1, port 7
 t=20000: Handling entry event packetin(12,102) at switch 2, port 1
-t=20600: Handling event count_to_10(0) at switch 0, port 196
+t=20600: Handling event count_to_10(0) at switch 0, port 255
 at 0
 t=20600: Handling event count_to_10(0) at switch 1, port 196
 at 0
-t=20600: Handling event count_to_10(0) at switch 2, port 196
+t=20600: Handling event count_to_10(0) at switch 2, port 3
 at 0
-t=21200: Handling event count_to_10(1) at switch 0, port 196
+t=21200: Handling event count_to_10(1) at switch 0, port 255
 1
 t=21200: Handling event count_to_10(1) at switch 1, port 196
 1
-t=21200: Handling event count_to_10(1) at switch 2, port 196
+t=21200: Handling event count_to_10(1) at switch 2, port 3
 1
-t=21800: Handling event count_to_10(2) at switch 0, port 196
+t=21800: Handling event count_to_10(2) at switch 0, port 255
 2
 t=21800: Handling event count_to_10(2) at switch 1, port 196
 2
-t=21800: Handling event count_to_10(2) at switch 2, port 196
+t=21800: Handling event count_to_10(2) at switch 2, port 3
 2
-t=22400: Handling event count_to_10(3) at switch 0, port 196
+t=22400: Handling event count_to_10(3) at switch 0, port 255
 3
 t=22400: Handling event count_to_10(3) at switch 1, port 196
 3
-t=22400: Handling event count_to_10(3) at switch 2, port 196
+t=22400: Handling event count_to_10(3) at switch 2, port 3
 3
-t=23000: Handling event count_to_10(4) at switch 0, port 196
+t=23000: Handling event count_to_10(4) at switch 0, port 255
 4
 t=23000: Handling event count_to_10(4) at switch 1, port 196
 4
-t=23000: Handling event count_to_10(4) at switch 2, port 196
+t=23000: Handling event count_to_10(4) at switch 2, port 3
 4
-t=23600: Handling event count_to_10(5) at switch 0, port 196
+t=23600: Handling event count_to_10(5) at switch 0, port 255
 5
 t=23600: Handling event count_to_10(5) at switch 1, port 196
 5
-t=23600: Handling event count_to_10(5) at switch 2, port 196
+t=23600: Handling event count_to_10(5) at switch 2, port 3
 5
-t=24200: Handling event count_to_10(6) at switch 0, port 196
+t=24200: Handling event count_to_10(6) at switch 0, port 255
 6
 t=24200: Handling event count_to_10(6) at switch 1, port 196
 6
-t=24200: Handling event count_to_10(6) at switch 2, port 196
+t=24200: Handling event count_to_10(6) at switch 2, port 3
 6
-t=24800: Handling event count_to_10(7) at switch 0, port 196
+t=24800: Handling event count_to_10(7) at switch 0, port 255
 7
 t=24800: Handling event count_to_10(7) at switch 1, port 196
 7
-t=24800: Handling event count_to_10(7) at switch 2, port 196
+t=24800: Handling event count_to_10(7) at switch 2, port 3
 7
-t=25400: Handling event count_to_10(8) at switch 0, port 196
+t=25400: Handling event count_to_10(8) at switch 0, port 255
 8
 t=25400: Handling event count_to_10(8) at switch 1, port 196
 8
-t=25400: Handling event count_to_10(8) at switch 2, port 196
+t=25400: Handling event count_to_10(8) at switch 2, port 3
 8
-t=26000: Handling event count_to_10(9) at switch 0, port 196
+t=26000: Handling event count_to_10(9) at switch 0, port 255
 9
 t=26000: Handling event count_to_10(9) at switch 1, port 196
 9
-t=26000: Handling event count_to_10(9) at switch 2, port 196
+t=26000: Handling event count_to_10(9) at switch 2, port 3
 9
-t=26600: Handling event count_to_10(10) at switch 0, port 196
+t=26600: Handling event count_to_10(10) at switch 0, port 255
 10
 t=26600: Handling event count_to_10(10) at switch 1, port 196
 10
-t=26600: Handling event count_to_10(10) at switch 2, port 196
+t=26600: Handling event count_to_10(10) at switch 2, port 3
 10
-t=27200: Handling event count_to_10(11) at switch 0, port 196
+t=27200: Handling event count_to_10(11) at switch 0, port 255
 got to 10
 t=27200: Handling event count_to_10(11) at switch 1, port 196
 got to 10
-t=27200: Handling event count_to_10(11) at switch 2, port 196
+t=27200: Handling event count_to_10(11) at switch 2, port 3
 got to 10
 t=40000: Handling entry event packetin(13,103) at switch 0, port 0
 t=40007: Handling entry event packetin(14,104) at switch 0, port 3
 t=40007: Handling entry event packetin(14,104) at switch 1, port 19
-t=40600: Handling event count_to_10(0) at switch 0, port 196
+t=40600: Handling event count_to_10(0) at switch 0, port 255
 at 0
-t=40607: Handling event count_to_10(0) at switch 0, port 196
+t=40607: Handling event count_to_10(0) at switch 0, port 255
 at 0
 t=40607: Handling event count_to_10(0) at switch 1, port 196
 at 0
-t=41200: Handling event count_to_10(1) at switch 0, port 196
+t=41200: Handling event count_to_10(1) at switch 0, port 255
 1
-t=41207: Handling event count_to_10(1) at switch 0, port 196
+t=41207: Handling event count_to_10(1) at switch 0, port 255
 1
 t=41207: Handling event count_to_10(1) at switch 1, port 196
 1
-t=41800: Handling event count_to_10(2) at switch 0, port 196
+t=41800: Handling event count_to_10(2) at switch 0, port 255
 2
-t=41807: Handling event count_to_10(2) at switch 0, port 196
+t=41807: Handling event count_to_10(2) at switch 0, port 255
 2
 t=41807: Handling event count_to_10(2) at switch 1, port 196
 2
-t=42400: Handling event count_to_10(3) at switch 0, port 196
+t=42400: Handling event count_to_10(3) at switch 0, port 255
 3
-t=42407: Handling event count_to_10(3) at switch 0, port 196
+t=42407: Handling event count_to_10(3) at switch 0, port 255
 3
 t=42407: Handling event count_to_10(3) at switch 1, port 196
 3
-t=43000: Handling event count_to_10(4) at switch 0, port 196
+t=43000: Handling event count_to_10(4) at switch 0, port 255
 4
-t=43007: Handling event count_to_10(4) at switch 0, port 196
+t=43007: Handling event count_to_10(4) at switch 0, port 255
 4
 t=43007: Handling event count_to_10(4) at switch 1, port 196
 4
-t=43600: Handling event count_to_10(5) at switch 0, port 196
+t=43600: Handling event count_to_10(5) at switch 0, port 255
 5
-t=43607: Handling event count_to_10(5) at switch 0, port 196
+t=43607: Handling event count_to_10(5) at switch 0, port 255
 5
 t=43607: Handling event count_to_10(5) at switch 1, port 196
 5
-t=44200: Handling event count_to_10(6) at switch 0, port 196
+t=44200: Handling event count_to_10(6) at switch 0, port 255
 6
-t=44207: Handling event count_to_10(6) at switch 0, port 196
+t=44207: Handling event count_to_10(6) at switch 0, port 255
 6
 t=44207: Handling event count_to_10(6) at switch 1, port 196
 6
-t=44800: Handling event count_to_10(7) at switch 0, port 196
+t=44800: Handling event count_to_10(7) at switch 0, port 255
 7
-t=44807: Handling event count_to_10(7) at switch 0, port 196
+t=44807: Handling event count_to_10(7) at switch 0, port 255
 7
 t=44807: Handling event count_to_10(7) at switch 1, port 196
 7
-t=45400: Handling event count_to_10(8) at switch 0, port 196
+t=45400: Handling event count_to_10(8) at switch 0, port 255
 8
-t=45407: Handling event count_to_10(8) at switch 0, port 196
+t=45407: Handling event count_to_10(8) at switch 0, port 255
 8
 t=45407: Handling event count_to_10(8) at switch 1, port 196
 8
-t=46000: Handling event count_to_10(9) at switch 0, port 196
+t=46000: Handling event count_to_10(9) at switch 0, port 255
 9
-t=46007: Handling event count_to_10(9) at switch 0, port 196
+t=46007: Handling event count_to_10(9) at switch 0, port 255
 9
 t=46007: Handling event count_to_10(9) at switch 1, port 196
 9
-t=46600: Handling event count_to_10(10) at switch 0, port 196
+t=46600: Handling event count_to_10(10) at switch 0, port 255
 10
-t=46607: Handling event count_to_10(10) at switch 0, port 196
+t=46607: Handling event count_to_10(10) at switch 0, port 255
 10
 t=46607: Handling event count_to_10(10) at switch 1, port 196
 10
-t=47200: Handling event count_to_10(11) at switch 0, port 196
+t=47200: Handling event count_to_10(11) at switch 0, port 255
 got to 10
-t=47207: Handling event count_to_10(11) at switch 0, port 196
+t=47207: Handling event count_to_10(11) at switch 0, port 255
 got to 10
 t=47207: Handling event count_to_10(11) at switch 1, port 196
 got to 10

--- a/test/expected/basics_output.txt
+++ b/test/expected/basics_output.txt
@@ -11,205 +11,205 @@ dpt: Auto-detected specification file examples/interp_tests/basics.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling entry event packetin(10,100) at switch 0
-t=600: Handling event count_to_10(0) at switch 0
+t=0: Handling entry event packetin(10,100) at switch 0, port 0
+t=600: Handling event count_to_10(0) at switch 0, port 196
 at 0
-t=1200: Handling event count_to_10(1) at switch 0
+t=1200: Handling event count_to_10(1) at switch 0, port 196
 1
-t=1800: Handling event count_to_10(2) at switch 0
+t=1800: Handling event count_to_10(2) at switch 0, port 196
 2
-t=2400: Handling event count_to_10(3) at switch 0
+t=2400: Handling event count_to_10(3) at switch 0, port 196
 3
-t=3000: Handling event count_to_10(4) at switch 0
+t=3000: Handling event count_to_10(4) at switch 0, port 196
 4
-t=3600: Handling event count_to_10(5) at switch 0
+t=3600: Handling event count_to_10(5) at switch 0, port 196
 5
-t=4200: Handling event count_to_10(6) at switch 0
+t=4200: Handling event count_to_10(6) at switch 0, port 196
 6
-t=4800: Handling event count_to_10(7) at switch 0
+t=4800: Handling event count_to_10(7) at switch 0, port 196
 7
-t=5400: Handling event count_to_10(8) at switch 0
+t=5400: Handling event count_to_10(8) at switch 0, port 196
 8
-t=6000: Handling event count_to_10(9) at switch 0
+t=6000: Handling event count_to_10(9) at switch 0, port 196
 9
-t=6600: Handling event count_to_10(10) at switch 0
+t=6600: Handling event count_to_10(10) at switch 0, port 196
 10
-t=7200: Handling event count_to_10(11) at switch 0
+t=7200: Handling event count_to_10(11) at switch 0, port 196
 got to 10
-t=10000: Handling entry event packetin(11,101) at switch 0
-t=10600: Handling event count_to_10(0) at switch 0
+t=10000: Handling entry event packetin(11,101) at switch 0, port 0
+t=10600: Handling event count_to_10(0) at switch 0, port 196
 at 0
-t=11200: Handling event count_to_10(1) at switch 0
+t=11200: Handling event count_to_10(1) at switch 0, port 196
 1
-t=11800: Handling event count_to_10(2) at switch 0
+t=11800: Handling event count_to_10(2) at switch 0, port 196
 2
-t=12400: Handling event count_to_10(3) at switch 0
+t=12400: Handling event count_to_10(3) at switch 0, port 196
 3
-t=13000: Handling event count_to_10(4) at switch 0
+t=13000: Handling event count_to_10(4) at switch 0, port 196
 4
-t=13600: Handling event count_to_10(5) at switch 0
+t=13600: Handling event count_to_10(5) at switch 0, port 196
 5
-t=14200: Handling event count_to_10(6) at switch 0
+t=14200: Handling event count_to_10(6) at switch 0, port 196
 6
-t=14800: Handling event count_to_10(7) at switch 0
+t=14800: Handling event count_to_10(7) at switch 0, port 196
 7
-t=15400: Handling event count_to_10(8) at switch 0
+t=15400: Handling event count_to_10(8) at switch 0, port 196
 8
-t=16000: Handling event count_to_10(9) at switch 0
+t=16000: Handling event count_to_10(9) at switch 0, port 196
 9
-t=16600: Handling event count_to_10(10) at switch 0
+t=16600: Handling event count_to_10(10) at switch 0, port 196
 10
-t=17200: Handling event count_to_10(11) at switch 0
+t=17200: Handling event count_to_10(11) at switch 0, port 196
 got to 10
-t=20000: Handling entry event packetin(12,102) at switch 0
-t=20000: Handling entry event packetin(12,102) at switch 1
-t=20000: Handling entry event packetin(12,102) at switch 2
-t=20600: Handling event count_to_10(0) at switch 0
+t=20000: Handling entry event packetin(12,102) at switch 0, port 0
+t=20000: Handling entry event packetin(12,102) at switch 1, port 0
+t=20000: Handling entry event packetin(12,102) at switch 2, port 0
+t=20600: Handling event count_to_10(0) at switch 0, port 196
 at 0
-t=20600: Handling event count_to_10(0) at switch 1
+t=20600: Handling event count_to_10(0) at switch 1, port 196
 at 0
-t=20600: Handling event count_to_10(0) at switch 2
+t=20600: Handling event count_to_10(0) at switch 2, port 196
 at 0
-t=21200: Handling event count_to_10(1) at switch 0
+t=21200: Handling event count_to_10(1) at switch 0, port 196
 1
-t=21200: Handling event count_to_10(1) at switch 1
+t=21200: Handling event count_to_10(1) at switch 1, port 196
 1
-t=21200: Handling event count_to_10(1) at switch 2
+t=21200: Handling event count_to_10(1) at switch 2, port 196
 1
-t=21800: Handling event count_to_10(2) at switch 0
+t=21800: Handling event count_to_10(2) at switch 0, port 196
 2
-t=21800: Handling event count_to_10(2) at switch 1
+t=21800: Handling event count_to_10(2) at switch 1, port 196
 2
-t=21800: Handling event count_to_10(2) at switch 2
+t=21800: Handling event count_to_10(2) at switch 2, port 196
 2
-t=22400: Handling event count_to_10(3) at switch 0
+t=22400: Handling event count_to_10(3) at switch 0, port 196
 3
-t=22400: Handling event count_to_10(3) at switch 1
+t=22400: Handling event count_to_10(3) at switch 1, port 196
 3
-t=22400: Handling event count_to_10(3) at switch 2
+t=22400: Handling event count_to_10(3) at switch 2, port 196
 3
-t=23000: Handling event count_to_10(4) at switch 0
+t=23000: Handling event count_to_10(4) at switch 0, port 196
 4
-t=23000: Handling event count_to_10(4) at switch 1
+t=23000: Handling event count_to_10(4) at switch 1, port 196
 4
-t=23000: Handling event count_to_10(4) at switch 2
+t=23000: Handling event count_to_10(4) at switch 2, port 196
 4
-t=23600: Handling event count_to_10(5) at switch 0
+t=23600: Handling event count_to_10(5) at switch 0, port 196
 5
-t=23600: Handling event count_to_10(5) at switch 1
+t=23600: Handling event count_to_10(5) at switch 1, port 196
 5
-t=23600: Handling event count_to_10(5) at switch 2
+t=23600: Handling event count_to_10(5) at switch 2, port 196
 5
-t=24200: Handling event count_to_10(6) at switch 0
+t=24200: Handling event count_to_10(6) at switch 0, port 196
 6
-t=24200: Handling event count_to_10(6) at switch 1
+t=24200: Handling event count_to_10(6) at switch 1, port 196
 6
-t=24200: Handling event count_to_10(6) at switch 2
+t=24200: Handling event count_to_10(6) at switch 2, port 196
 6
-t=24800: Handling event count_to_10(7) at switch 0
+t=24800: Handling event count_to_10(7) at switch 0, port 196
 7
-t=24800: Handling event count_to_10(7) at switch 1
+t=24800: Handling event count_to_10(7) at switch 1, port 196
 7
-t=24800: Handling event count_to_10(7) at switch 2
+t=24800: Handling event count_to_10(7) at switch 2, port 196
 7
-t=25400: Handling event count_to_10(8) at switch 0
+t=25400: Handling event count_to_10(8) at switch 0, port 196
 8
-t=25400: Handling event count_to_10(8) at switch 1
+t=25400: Handling event count_to_10(8) at switch 1, port 196
 8
-t=25400: Handling event count_to_10(8) at switch 2
+t=25400: Handling event count_to_10(8) at switch 2, port 196
 8
-t=26000: Handling event count_to_10(9) at switch 0
+t=26000: Handling event count_to_10(9) at switch 0, port 196
 9
-t=26000: Handling event count_to_10(9) at switch 1
+t=26000: Handling event count_to_10(9) at switch 1, port 196
 9
-t=26000: Handling event count_to_10(9) at switch 2
+t=26000: Handling event count_to_10(9) at switch 2, port 196
 9
-t=26600: Handling event count_to_10(10) at switch 0
+t=26600: Handling event count_to_10(10) at switch 0, port 196
 10
-t=26600: Handling event count_to_10(10) at switch 1
+t=26600: Handling event count_to_10(10) at switch 1, port 196
 10
-t=26600: Handling event count_to_10(10) at switch 2
+t=26600: Handling event count_to_10(10) at switch 2, port 196
 10
-t=27200: Handling event count_to_10(11) at switch 0
+t=27200: Handling event count_to_10(11) at switch 0, port 196
 got to 10
-t=27200: Handling event count_to_10(11) at switch 1
+t=27200: Handling event count_to_10(11) at switch 1, port 196
 got to 10
-t=27200: Handling event count_to_10(11) at switch 2
+t=27200: Handling event count_to_10(11) at switch 2, port 196
 got to 10
-t=40000: Handling entry event packetin(13,103) at switch 0
-t=40007: Handling entry event packetin(14,104) at switch 0
-t=40007: Handling entry event packetin(14,104) at switch 1
-t=40600: Handling event count_to_10(0) at switch 0
+t=40000: Handling entry event packetin(13,103) at switch 0, port 0
+t=40007: Handling entry event packetin(14,104) at switch 0, port 0
+t=40007: Handling entry event packetin(14,104) at switch 1, port 0
+t=40600: Handling event count_to_10(0) at switch 0, port 196
 at 0
-t=40607: Handling event count_to_10(0) at switch 0
+t=40607: Handling event count_to_10(0) at switch 0, port 196
 at 0
-t=40607: Handling event count_to_10(0) at switch 1
+t=40607: Handling event count_to_10(0) at switch 1, port 196
 at 0
-t=41200: Handling event count_to_10(1) at switch 0
+t=41200: Handling event count_to_10(1) at switch 0, port 196
 1
-t=41207: Handling event count_to_10(1) at switch 0
+t=41207: Handling event count_to_10(1) at switch 0, port 196
 1
-t=41207: Handling event count_to_10(1) at switch 1
+t=41207: Handling event count_to_10(1) at switch 1, port 196
 1
-t=41800: Handling event count_to_10(2) at switch 0
+t=41800: Handling event count_to_10(2) at switch 0, port 196
 2
-t=41807: Handling event count_to_10(2) at switch 0
+t=41807: Handling event count_to_10(2) at switch 0, port 196
 2
-t=41807: Handling event count_to_10(2) at switch 1
+t=41807: Handling event count_to_10(2) at switch 1, port 196
 2
-t=42400: Handling event count_to_10(3) at switch 0
+t=42400: Handling event count_to_10(3) at switch 0, port 196
 3
-t=42407: Handling event count_to_10(3) at switch 0
+t=42407: Handling event count_to_10(3) at switch 0, port 196
 3
-t=42407: Handling event count_to_10(3) at switch 1
+t=42407: Handling event count_to_10(3) at switch 1, port 196
 3
-t=43000: Handling event count_to_10(4) at switch 0
+t=43000: Handling event count_to_10(4) at switch 0, port 196
 4
-t=43007: Handling event count_to_10(4) at switch 0
+t=43007: Handling event count_to_10(4) at switch 0, port 196
 4
-t=43007: Handling event count_to_10(4) at switch 1
+t=43007: Handling event count_to_10(4) at switch 1, port 196
 4
-t=43600: Handling event count_to_10(5) at switch 0
+t=43600: Handling event count_to_10(5) at switch 0, port 196
 5
-t=43607: Handling event count_to_10(5) at switch 0
+t=43607: Handling event count_to_10(5) at switch 0, port 196
 5
-t=43607: Handling event count_to_10(5) at switch 1
+t=43607: Handling event count_to_10(5) at switch 1, port 196
 5
-t=44200: Handling event count_to_10(6) at switch 0
+t=44200: Handling event count_to_10(6) at switch 0, port 196
 6
-t=44207: Handling event count_to_10(6) at switch 0
+t=44207: Handling event count_to_10(6) at switch 0, port 196
 6
-t=44207: Handling event count_to_10(6) at switch 1
+t=44207: Handling event count_to_10(6) at switch 1, port 196
 6
-t=44800: Handling event count_to_10(7) at switch 0
+t=44800: Handling event count_to_10(7) at switch 0, port 196
 7
-t=44807: Handling event count_to_10(7) at switch 0
+t=44807: Handling event count_to_10(7) at switch 0, port 196
 7
-t=44807: Handling event count_to_10(7) at switch 1
+t=44807: Handling event count_to_10(7) at switch 1, port 196
 7
-t=45400: Handling event count_to_10(8) at switch 0
+t=45400: Handling event count_to_10(8) at switch 0, port 196
 8
-t=45407: Handling event count_to_10(8) at switch 0
+t=45407: Handling event count_to_10(8) at switch 0, port 196
 8
-t=45407: Handling event count_to_10(8) at switch 1
+t=45407: Handling event count_to_10(8) at switch 1, port 196
 8
-t=46000: Handling event count_to_10(9) at switch 0
+t=46000: Handling event count_to_10(9) at switch 0, port 196
 9
-t=46007: Handling event count_to_10(9) at switch 0
+t=46007: Handling event count_to_10(9) at switch 0, port 196
 9
-t=46007: Handling event count_to_10(9) at switch 1
+t=46007: Handling event count_to_10(9) at switch 1, port 196
 9
-t=46600: Handling event count_to_10(10) at switch 0
+t=46600: Handling event count_to_10(10) at switch 0, port 196
 10
-t=46607: Handling event count_to_10(10) at switch 0
+t=46607: Handling event count_to_10(10) at switch 0, port 196
 10
-t=46607: Handling event count_to_10(10) at switch 1
+t=46607: Handling event count_to_10(10) at switch 1, port 196
 10
-t=47200: Handling event count_to_10(11) at switch 0
+t=47200: Handling event count_to_10(11) at switch 0, port 196
 got to 10
-t=47207: Handling event count_to_10(11) at switch 0
+t=47207: Handling event count_to_10(11) at switch 0, port 196
 got to 10
-t=47207: Handling event count_to_10(11) at switch 1
+t=47207: Handling event count_to_10(11) at switch 1, port 196
 got to 10
 dpt: Final State:
 
@@ -220,11 +220,11 @@ Switch 0 : {
  Events :   [ ]
 
  Exits :    [
-    continue(10,100) at t=0
-    continue(11,101) at t=10000
-    continue(12,102) at t=20000
-    continue(13,103) at t=40000
-    continue(14,104) at t=40007
+    continue(10,100) at port -1, t=0
+    continue(11,101) at port -1, t=10000
+    continue(12,102) at port -1, t=20000
+    continue(13,103) at port -1, t=40000
+    continue(14,104) at port -1, t=40007
   ]
 
  entry events handled: 5
@@ -238,8 +238,8 @@ Switch 1 : {
  Events :   [ ]
 
  Exits :    [
-    continue(12,102) at t=20000
-    continue(14,104) at t=40007
+    continue(12,102) at port -1, t=20000
+    continue(14,104) at port -1, t=40007
   ]
 
  entry events handled: 2
@@ -253,7 +253,7 @@ Switch 2 : {
  Events :   [ ]
 
  Exits :    [
-    continue(12,102) at t=20000
+    continue(12,102) at port -1, t=20000
   ]
 
  entry events handled: 1

--- a/test/expected/bouncing_output.txt
+++ b/test/expected/bouncing_output.txt
@@ -1,0 +1,263 @@
+dpt: Parsing ...
+
+In examples/interp_tests/bouncing.dpt: 
+
+73|    generate count_to_10 (0); // Dangerous, because this happens at linerate
+               ~~~~~~~~~~~~~~~
+
+warning: examples/interp_tests/bouncing.dpt: Unconditional generation of potential non-exit event in entry handler!
+
+dpt: Auto-detected specification file examples/interp_tests/bouncing.json
+dpt: Simulating...
+dpt: Using random seed: 0
+
+t=0: Handling entry event packetin(10,100) at switch 0, port 0
+t=600: Handling event count_to_10(0) at switch 0, port 255
+at 0
+t=1200: Handling event count_to_10(1) at switch 1, port 0
+1
+t=1800: Handling event count_to_10(2) at switch 1, port 196
+2
+t=2400: Handling event count_to_10(3) at switch 2, port 0
+3
+t=3000: Handling event count_to_10(4) at switch 2, port 3
+4
+t=3600: Handling event count_to_10(5) at switch 0, port 0
+5
+t=4200: Handling event count_to_10(6) at switch 0, port 255
+6
+t=4800: Handling event count_to_10(7) at switch 1, port 0
+7
+t=5400: Handling event count_to_10(8) at switch 1, port 196
+8
+t=6000: Handling event count_to_10(9) at switch 2, port 0
+9
+t=6600: Handling event count_to_10(10) at switch 2, port 3
+10
+t=7200: Handling event count_to_10(11) at switch 0, port 0
+got to 10
+t=10000: Handling entry event packetin(11,101) at switch 0, port 0
+t=10600: Handling event count_to_10(0) at switch 0, port 255
+at 0
+t=11200: Handling event count_to_10(1) at switch 1, port 0
+1
+t=11800: Handling event count_to_10(2) at switch 1, port 196
+2
+t=12400: Handling event count_to_10(3) at switch 2, port 0
+3
+t=13000: Handling event count_to_10(4) at switch 2, port 3
+4
+t=13600: Handling event count_to_10(5) at switch 0, port 0
+5
+t=14200: Handling event count_to_10(6) at switch 0, port 255
+6
+t=14800: Handling event count_to_10(7) at switch 1, port 0
+7
+t=15400: Handling event count_to_10(8) at switch 1, port 196
+8
+t=16000: Handling event count_to_10(9) at switch 2, port 0
+9
+t=16600: Handling event count_to_10(10) at switch 2, port 3
+10
+t=17200: Handling event count_to_10(11) at switch 0, port 0
+got to 10
+t=20000: Handling entry event packetin(12,102) at switch 0, port 0
+t=20000: Handling entry event packetin(12,102) at switch 1, port 7
+t=20000: Handling entry event packetin(12,102) at switch 2, port 1
+t=20600: Handling event count_to_10(0) at switch 0, port 255
+at 0
+t=20600: Handling event count_to_10(0) at switch 1, port 196
+at 0
+t=20600: Handling event count_to_10(0) at switch 2, port 3
+at 0
+t=21200: Handling event count_to_10(1) at switch 0, port 0
+1
+t=21200: Handling event count_to_10(1) at switch 1, port 0
+1
+t=21200: Handling event count_to_10(1) at switch 2, port 0
+1
+t=21800: Handling event count_to_10(2) at switch 0, port 255
+2
+t=21800: Handling event count_to_10(2) at switch 1, port 196
+2
+t=21800: Handling event count_to_10(2) at switch 2, port 3
+2
+t=22400: Handling event count_to_10(3) at switch 0, port 0
+3
+t=22400: Handling event count_to_10(3) at switch 1, port 0
+3
+t=22400: Handling event count_to_10(3) at switch 2, port 0
+3
+t=23000: Handling event count_to_10(4) at switch 0, port 255
+4
+t=23000: Handling event count_to_10(4) at switch 1, port 196
+4
+t=23000: Handling event count_to_10(4) at switch 2, port 3
+4
+t=23600: Handling event count_to_10(5) at switch 0, port 0
+5
+t=23600: Handling event count_to_10(5) at switch 1, port 0
+5
+t=23600: Handling event count_to_10(5) at switch 2, port 0
+5
+t=24200: Handling event count_to_10(6) at switch 0, port 255
+6
+t=24200: Handling event count_to_10(6) at switch 1, port 196
+6
+t=24200: Handling event count_to_10(6) at switch 2, port 3
+6
+t=24800: Handling event count_to_10(7) at switch 0, port 0
+7
+t=24800: Handling event count_to_10(7) at switch 1, port 0
+7
+t=24800: Handling event count_to_10(7) at switch 2, port 0
+7
+t=25400: Handling event count_to_10(8) at switch 0, port 255
+8
+t=25400: Handling event count_to_10(8) at switch 1, port 196
+8
+t=25400: Handling event count_to_10(8) at switch 2, port 3
+8
+t=26000: Handling event count_to_10(9) at switch 0, port 0
+9
+t=26000: Handling event count_to_10(9) at switch 1, port 0
+9
+t=26000: Handling event count_to_10(9) at switch 2, port 0
+9
+t=26600: Handling event count_to_10(10) at switch 0, port 255
+10
+t=26600: Handling event count_to_10(10) at switch 1, port 196
+10
+t=26600: Handling event count_to_10(10) at switch 2, port 3
+10
+t=27200: Handling event count_to_10(11) at switch 0, port 0
+got to 10
+t=27200: Handling event count_to_10(11) at switch 1, port 0
+got to 10
+t=27200: Handling event count_to_10(11) at switch 2, port 0
+got to 10
+t=40000: Handling entry event packetin(13,103) at switch 0, port 0
+t=40007: Handling entry event packetin(14,104) at switch 0, port 3
+t=40007: Handling entry event packetin(14,104) at switch 1, port 19
+t=40600: Handling event count_to_10(0) at switch 0, port 255
+at 0
+t=40607: Handling event count_to_10(0) at switch 0, port 255
+at 0
+t=40607: Handling event count_to_10(0) at switch 1, port 196
+at 0
+t=41200: Handling event count_to_10(1) at switch 1, port 0
+1
+t=41207: Handling event count_to_10(1) at switch 1, port 0
+1
+t=41207: Handling event count_to_10(1) at switch 2, port 0
+1
+t=41800: Handling event count_to_10(2) at switch 1, port 196
+2
+t=41807: Handling event count_to_10(2) at switch 1, port 196
+2
+t=41807: Handling event count_to_10(2) at switch 2, port 3
+2
+t=42400: Handling event count_to_10(3) at switch 2, port 0
+3
+t=42407: Handling event count_to_10(3) at switch 0, port 0
+3
+t=42407: Handling event count_to_10(3) at switch 2, port 0
+3
+t=43000: Handling event count_to_10(4) at switch 2, port 3
+4
+t=43007: Handling event count_to_10(4) at switch 0, port 255
+4
+t=43007: Handling event count_to_10(4) at switch 2, port 3
+4
+t=43600: Handling event count_to_10(5) at switch 0, port 0
+5
+t=43607: Handling event count_to_10(5) at switch 0, port 0
+5
+t=43607: Handling event count_to_10(5) at switch 1, port 0
+5
+t=44200: Handling event count_to_10(6) at switch 0, port 255
+6
+t=44207: Handling event count_to_10(6) at switch 0, port 255
+6
+t=44207: Handling event count_to_10(6) at switch 1, port 196
+6
+t=44800: Handling event count_to_10(7) at switch 1, port 0
+7
+t=44807: Handling event count_to_10(7) at switch 1, port 0
+7
+t=44807: Handling event count_to_10(7) at switch 2, port 0
+7
+t=45400: Handling event count_to_10(8) at switch 1, port 196
+8
+t=45407: Handling event count_to_10(8) at switch 1, port 196
+8
+t=45407: Handling event count_to_10(8) at switch 2, port 3
+8
+t=46000: Handling event count_to_10(9) at switch 2, port 0
+9
+t=46007: Handling event count_to_10(9) at switch 0, port 0
+9
+t=46007: Handling event count_to_10(9) at switch 2, port 0
+9
+t=46600: Handling event count_to_10(10) at switch 2, port 3
+10
+t=46607: Handling event count_to_10(10) at switch 0, port 255
+10
+t=46607: Handling event count_to_10(10) at switch 2, port 3
+10
+t=47200: Handling event count_to_10(11) at switch 0, port 0
+got to 10
+t=47207: Handling event count_to_10(11) at switch 0, port 0
+got to 10
+t=47207: Handling event count_to_10(11) at switch 1, port 0
+got to 10
+dpt: Final State:
+
+Switch 0 : {
+
+ Pipeline : [ ]
+
+ Events :   [ ]
+
+ Exits :    [
+    continue(10,100) at port -1, t=0
+    continue(11,101) at port -1, t=10000
+    continue(12,102) at port -1, t=20000
+    continue(13,103) at port -1, t=40000
+    continue(14,104) at port -1, t=40007
+  ]
+
+ entry events handled: 5
+ total events handled: 37
+
+}
+Switch 1 : {
+
+ Pipeline : [ ]
+
+ Events :   [ ]
+
+ Exits :    [
+    continue(12,102) at port -1, t=20000
+    continue(14,104) at port -1, t=40007
+  ]
+
+ entry events handled: 2
+ total events handled: 34
+
+}
+Switch 2 : {
+
+ Pipeline : [ ]
+
+ Events :   [ ]
+
+ Exits :    [
+    continue(12,102) at port -1, t=20000
+  ]
+
+ entry events handled: 1
+ total events handled: 33
+
+}
+dpt: Done

--- a/test/expected/chain_stateful_firewall_output.txt
+++ b/test/expected/chain_stateful_firewall_output.txt
@@ -8,26 +8,26 @@ Mapped (10, 100) to index 3
 t=11000600: Handling event update_last_seen(3,11000000) at switch 0, port 0
 t=11001200: Handling event update_last_seen(3,11000000) at switch 1, port 0
 t=11001800: Handling event update_last_seen(3,11000000) at switch 2, port 0
-t=11100000: Handling entry event packetin(11,101,0) at switch 1, port 0
+t=11100000: Handling entry event packetin(11,101,0) at switch 1, port 1
 Mapped (11, 101) to index 2
 t=11100600: Handling event update_last_seen(2,11100000) at switch 0, port 0
 t=11101200: Handling event update_last_seen(2,11100000) at switch 1, port 0
 t=11101800: Handling event update_last_seen(2,11100000) at switch 2, port 0
 t=11200000: Handling entry event packetin(13,103,1) at switch 0, port 0
 Mapped (103, 13) to index 2
-t=11200000: Handling entry event packetin(13,103,1) at switch 1, port 0
+t=11200000: Handling entry event packetin(13,103,1) at switch 1, port 1
 Mapped (103, 13) to index 2
 t=11200000: Handling entry event packetin(13,103,1) at switch 2, port 0
 Mapped (103, 13) to index 2
 t=11300000: Handling entry event packetin(101,11,1) at switch 0, port 0
 Mapped (11, 101) to index 2
-t=11300000: Handling entry event packetin(101,11,1) at switch 1, port 0
+t=11300000: Handling entry event packetin(101,11,1) at switch 1, port 1
 Mapped (11, 101) to index 2
 t=11300000: Handling entry event packetin(101,11,1) at switch 2, port 0
 Mapped (11, 101) to index 2
 t=11400000: Handling entry event packetin(100,10,1) at switch 0, port 0
 Mapped (10, 100) to index 3
-t=11400000: Handling entry event packetin(100,10,1) at switch 1, port 0
+t=11400000: Handling entry event packetin(100,10,1) at switch 1, port 1
 Mapped (10, 100) to index 3
 t=11400000: Handling entry event packetin(100,10,1) at switch 2, port 0
 Mapped (10, 100) to index 3

--- a/test/expected/chain_stateful_firewall_output.txt
+++ b/test/expected/chain_stateful_firewall_output.txt
@@ -3,33 +3,33 @@ dpt: Auto-detected specification file examples/interp_tests/chain_stateful_firew
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=11000000: Handling entry event packetin(10,100,0) at switch 0
+t=11000000: Handling entry event packetin(10,100,0) at switch 0, port 0
 Mapped (10, 100) to index 3
-t=11000600: Handling event update_last_seen(3,11000000) at switch 0
-t=11001200: Handling event update_last_seen(3,11000000) at switch 1
-t=11001800: Handling event update_last_seen(3,11000000) at switch 2
-t=11100000: Handling entry event packetin(11,101,0) at switch 1
+t=11000600: Handling event update_last_seen(3,11000000) at switch 0, port 0
+t=11001200: Handling event update_last_seen(3,11000000) at switch 1, port 0
+t=11001800: Handling event update_last_seen(3,11000000) at switch 2, port 0
+t=11100000: Handling entry event packetin(11,101,0) at switch 1, port 0
 Mapped (11, 101) to index 2
-t=11100600: Handling event update_last_seen(2,11100000) at switch 0
-t=11101200: Handling event update_last_seen(2,11100000) at switch 1
-t=11101800: Handling event update_last_seen(2,11100000) at switch 2
-t=11200000: Handling entry event packetin(13,103,1) at switch 0
+t=11100600: Handling event update_last_seen(2,11100000) at switch 0, port 0
+t=11101200: Handling event update_last_seen(2,11100000) at switch 1, port 0
+t=11101800: Handling event update_last_seen(2,11100000) at switch 2, port 0
+t=11200000: Handling entry event packetin(13,103,1) at switch 0, port 0
 Mapped (103, 13) to index 2
-t=11200000: Handling entry event packetin(13,103,1) at switch 1
+t=11200000: Handling entry event packetin(13,103,1) at switch 1, port 0
 Mapped (103, 13) to index 2
-t=11200000: Handling entry event packetin(13,103,1) at switch 2
+t=11200000: Handling entry event packetin(13,103,1) at switch 2, port 0
 Mapped (103, 13) to index 2
-t=11300000: Handling entry event packetin(101,11,1) at switch 0
+t=11300000: Handling entry event packetin(101,11,1) at switch 0, port 0
 Mapped (11, 101) to index 2
-t=11300000: Handling entry event packetin(101,11,1) at switch 1
+t=11300000: Handling entry event packetin(101,11,1) at switch 1, port 0
 Mapped (11, 101) to index 2
-t=11300000: Handling entry event packetin(101,11,1) at switch 2
+t=11300000: Handling entry event packetin(101,11,1) at switch 2, port 0
 Mapped (11, 101) to index 2
-t=11400000: Handling entry event packetin(100,10,1) at switch 0
+t=11400000: Handling entry event packetin(100,10,1) at switch 0, port 0
 Mapped (10, 100) to index 3
-t=11400000: Handling entry event packetin(100,10,1) at switch 1
+t=11400000: Handling entry event packetin(100,10,1) at switch 1, port 0
 Mapped (10, 100) to index 3
-t=11400000: Handling entry event packetin(100,10,1) at switch 2
+t=11400000: Handling entry event packetin(100,10,1) at switch 2, port 0
 Mapped (10, 100) to index 3
 dpt: Final State:
 
@@ -42,10 +42,10 @@ Switch 0 : {
  Events :   [ ]
 
  Exits :    [
-    continue(100) at t=11000000
-    continue(103) at t=11200000
-    continue(11) at t=11300000
-    continue(10) at t=11400000
+    continue(100) at port -1, t=11000000
+    continue(103) at port -1, t=11200000
+    continue(11) at port -1, t=11300000
+    continue(10) at port -1, t=11400000
   ]
 
  entry events handled: 4
@@ -61,10 +61,10 @@ Switch 1 : {
  Events :   [ ]
 
  Exits :    [
-    continue(101) at t=11100000
-    continue(103) at t=11200000
-    continue(11) at t=11300000
-    continue(10) at t=11400000
+    continue(101) at port -1, t=11100000
+    continue(103) at port -1, t=11200000
+    continue(11) at port -1, t=11300000
+    continue(10) at port -1, t=11400000
   ]
 
  entry events handled: 4
@@ -80,9 +80,9 @@ Switch 2 : {
  Events :   [ ]
 
  Exits :    [
-    continue(103) at t=11200000
-    continue(11) at t=11300000
-    continue(10) at t=11400000
+    continue(103) at port -1, t=11200000
+    continue(11) at port -1, t=11300000
+    continue(10) at port -1, t=11400000
   ]
 
  entry events handled: 3

--- a/test/expected/chain_stateful_firewall_output.txt
+++ b/test/expected/chain_stateful_firewall_output.txt
@@ -2,8 +2,8 @@ dpt: Parsing ...
 
 In examples/interp_tests/chain_stateful_firewall.dpt: 
 
-46|    generate Event.sslocate(updater, head);
-                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+46|    generate_switch (head, updater);
+                                  ~~~~~~~
 
 warning: examples/interp_tests/chain_stateful_firewall.dpt: Conditional generation of potential non-exit event in entry handler.
 

--- a/test/expected/chain_stateful_firewall_output.txt
+++ b/test/expected/chain_stateful_firewall_output.txt
@@ -1,12 +1,4 @@
 dpt: Parsing ...
-
-In examples/interp_tests/chain_stateful_firewall.dpt: 
-
-46|    generate_switch (head, updater);
-                                  ~~~~~~~
-
-warning: examples/interp_tests/chain_stateful_firewall.dpt: Conditional generation of potential non-exit event in entry handler.
-
 dpt: Auto-detected specification file examples/interp_tests/chain_stateful_firewall.json
 dpt: Simulating...
 dpt: Using random seed: 0

--- a/test/expected/global_args_output.txt
+++ b/test/expected/global_args_output.txt
@@ -3,23 +3,23 @@ dpt: Auto-detected specification file examples/interp_tests/global_args.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling entry event in(1,1,1,1) at switch 0
-t=600: Handling event update_arr_ctr_arr1_ctr1(1,1) at switch 0
-t=10000: Handling entry event in(1,1,1,2) at switch 0
-t=10600: Handling event update_arr_ctr_arr1_ctr1(1,2) at switch 0
-t=20000: Handling entry event in(1,2,2,3) at switch 0
-t=20600: Handling event update_arr_ctr_arr1_ctr2(2,3) at switch 0
-t=30000: Handling entry event in(1,1,3,4) at switch 0
-t=30600: Handling event update_arr_ctr_arr1_ctr1(3,4) at switch 0
-t=40000: Handling entry event in(2,1,1,5) at switch 0
-t=40600: Handling event update_arr_ctr_arr2_ctr1(1,5) at switch 0
-t=50000: Handling entry event in(5,1,1,6) at switch 0
+t=0: Handling entry event in(1,1,1,1) at switch 0, port 0
+t=600: Handling event update_arr_ctr_arr1_ctr1(1,1) at switch 0, port 196
+t=10000: Handling entry event in(1,1,1,2) at switch 0, port 0
+t=10600: Handling event update_arr_ctr_arr1_ctr1(1,2) at switch 0, port 196
+t=20000: Handling entry event in(1,2,2,3) at switch 0, port 0
+t=20600: Handling event update_arr_ctr_arr1_ctr2(2,3) at switch 0, port 196
+t=30000: Handling entry event in(1,1,3,4) at switch 0, port 0
+t=30600: Handling event update_arr_ctr_arr1_ctr1(3,4) at switch 0, port 196
+t=40000: Handling entry event in(2,1,1,5) at switch 0, port 0
+t=40600: Handling event update_arr_ctr_arr2_ctr1(1,5) at switch 0, port 196
+t=50000: Handling entry event in(5,1,1,6) at switch 0, port 0
 Invalid array or counter id
-t=60000: Handling entry event in(3,2,2,7) at switch 0
-t=60600: Handling event update_arr_ctr_arr3_ctr2(2,7) at switch 0
-t=70000: Handling entry event in(3,2,3,8) at switch 0
-t=70600: Handling event update_arr_ctr_arr3_ctr2(3,8) at switch 0
-t=80000: Handling entry event in(3,7,3,9) at switch 0
+t=60000: Handling entry event in(3,2,2,7) at switch 0, port 0
+t=60600: Handling event update_arr_ctr_arr3_ctr2(2,7) at switch 0, port 196
+t=70000: Handling entry event in(3,2,3,8) at switch 0, port 0
+t=70600: Handling event update_arr_ctr_arr3_ctr2(3,8) at switch 0, port 196
+t=80000: Handling entry event in(3,7,3,9) at switch 0, port 0
 Invalid array or counter id
 dpt: Final State:
 
@@ -36,8 +36,8 @@ Switch 0 : {
  Events :   [ ]
 
  Exits :    [
-    bad_inputs(5,1) at t=50000
-    bad_inputs(3,7) at t=80000
+    bad_inputs(5,1) at port -1, t=50000
+    bad_inputs(3,7) at port -1, t=80000
   ]
 
  entry events handled: 9

--- a/test/expected/global_args_output.txt
+++ b/test/expected/global_args_output.txt
@@ -1,44 +1,4 @@
 dpt: Parsing ...
-
-In examples/interp_tests/global_args.dpt: 
-
-22|    | 1, 1 -> { generate update_arr_ctr(arr1, ctr1, idx, val); }
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-warning: examples/interp_tests/global_args.dpt: Conditional generation of potential non-exit event in entry handler.
-
-
-In examples/interp_tests/global_args.dpt: 
-
-23|    | 2, 1 -> { generate update_arr_ctr(arr2, ctr1, idx, val); }
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-warning: examples/interp_tests/global_args.dpt: Conditional generation of potential non-exit event in entry handler.
-
-
-In examples/interp_tests/global_args.dpt: 
-
-25|    | 1, 2 -> { generate update_arr_ctr(arr1, ctr2, idx, val); }
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-warning: examples/interp_tests/global_args.dpt: Conditional generation of potential non-exit event in entry handler.
-
-
-In examples/interp_tests/global_args.dpt: 
-
-26|    | 2, 2 -> { generate update_arr_ctr(arr2, ctr2, idx, val); }
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-warning: examples/interp_tests/global_args.dpt: Conditional generation of potential non-exit event in entry handler.
-
-
-In examples/interp_tests/global_args.dpt: 
-
-27|    | 3, 2 -> { generate update_arr_ctr(arr3, ctr2, idx, val); }
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-warning: examples/interp_tests/global_args.dpt: Conditional generation of potential non-exit event in entry handler.
-
 dpt: Auto-detected specification file examples/interp_tests/global_args.json
 dpt: Simulating...
 dpt: Using random seed: 0

--- a/test/expected/mac_learner_output.txt
+++ b/test/expected/mac_learner_output.txt
@@ -1,0 +1,132 @@
+dpt: Parsing ...
+dpt: Auto-detected specification file examples/interp_tests/mac_learner.json
+dpt: Simulating...
+dpt: Using random seed: 0
+
+t=0: Handling event eth(0,1) at switch 0, port 7
+t=600: Handling event learn_mac(0,7) at switch 0, port 196
+t=600: Handling event eth(0,1) at switch 1, port 0
+t=1200: Handling event learn_mac(0,0) at switch 1, port 196
+t=1200: Handling event eth(0,1) at switch 2, port 1
+t=1800: Handling event learn_mac(0,1) at switch 2, port 196
+t=1800: Handling event eth(0,1) at switch 3, port 2
+t=1800: Handling event eth(0,1) at switch 4, port 2
+t=2400: Handling event learn_mac(0,2) at switch 3, port 196
+t=2400: Handling event learn_mac(0,2) at switch 4, port 196
+t=10000: Handling event eth(1,0) at switch 3, port 9
+t=10600: Handling event eth(1,0) at switch 2, port 3
+t=10600: Handling event learn_mac(1,9) at switch 3, port 196
+t=11200: Handling event eth(1,0) at switch 1, port 2
+t=11200: Handling event learn_mac(1,3) at switch 2, port 196
+t=11800: Handling event eth(1,0) at switch 0, port 1
+t=11800: Handling event learn_mac(1,2) at switch 1, port 196
+t=12400: Handling event learn_mac(1,1) at switch 0, port 196
+t=20000: Handling event eth(2,1) at switch 4, port 42
+t=20600: Handling event eth(2,1) at switch 2, port 4
+t=20600: Handling event learn_mac(2,42) at switch 4, port 196
+t=21200: Handling event learn_mac(2,4) at switch 2, port 196
+t=21200: Handling event eth(2,1) at switch 3, port 2
+t=21800: Handling event learn_mac(2,2) at switch 3, port 196
+t=30000: Handling event eth(0,2) at switch 0, port 7
+t=30600: Handling event eth(0,2) at switch 1, port 0
+t=31200: Handling event eth(0,2) at switch 2, port 1
+t=31800: Handling event eth(0,2) at switch 4, port 2
+dpt: Final State:
+
+Switch 0 : {
+
+ Pipeline : [
+    0 : [1u1; 1u1; 0u1; 0u1]
+    1 : [1u1; 1u1; 0u1; 0u1]
+    2 : [7u8; 1u8; 0u8; 0u8]
+  ]
+
+ Events :   [ ]
+
+ Exits :    [
+    eth(0,1) at port -8, t=0
+    eth(1,0) at port 7, t=11800
+    eth(0,2) at port -8, t=30000
+  ]
+
+ entry events handled: 0
+ total events handled: 5
+
+}
+Switch 1 : {
+
+ Pipeline : [
+    0 : [1u1; 1u1; 0u1; 0u1]
+    1 : [1u1; 1u1; 0u1; 0u1]
+    2 : [0u8; 2u8; 0u8; 0u8]
+  ]
+
+ Events :   [ ]
+
+ Exits :    [
+    eth(0,1) at port -1, t=600
+    eth(0,2) at port -1, t=30600
+  ]
+
+ entry events handled: 0
+ total events handled: 5
+
+}
+Switch 2 : {
+
+ Pipeline : [
+    0 : [1u1; 1u1; 1u1; 0u1]
+    1 : [1u1; 1u1; 1u1; 0u1]
+    2 : [1u8; 3u8; 4u8; 0u8]
+  ]
+
+ Events :   [ ]
+
+ Exits :    [
+    eth(0,1) at port -2, t=1200
+  ]
+
+ entry events handled: 0
+ total events handled: 7
+
+}
+Switch 3 : {
+
+ Pipeline : [
+    0 : [1u1; 1u1; 1u1; 0u1]
+    1 : [1u1; 1u1; 1u1; 0u1]
+    2 : [2u8; 9u8; 2u8; 0u8]
+  ]
+
+ Events :   [ ]
+
+ Exits :    [
+    eth(0,1) at port -3, t=1800
+    eth(2,1) at port 9, t=21200
+  ]
+
+ entry events handled: 0
+ total events handled: 6
+
+}
+Switch 4 : {
+
+ Pipeline : [
+    0 : [1u1; 0u1; 1u1; 0u1]
+    1 : [1u1; 0u1; 1u1; 0u1]
+    2 : [2u8; 0u8; 42u8; 0u8]
+  ]
+
+ Events :   [ ]
+
+ Exits :    [
+    eth(0,1) at port -3, t=1800
+    eth(2,1) at port -43, t=20000
+    eth(0,2) at port 42, t=31800
+  ]
+
+ entry events handled: 0
+ total events handled: 5
+
+}
+dpt: Done

--- a/test/expected/match_output.txt
+++ b/test/expected/match_output.txt
@@ -3,39 +3,39 @@ dpt: Auto-detected specification file examples/interp_tests/match.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling entry event packetin(0) at switch 0
+t=0: Handling entry event packetin(0) at switch 0, port 0
 Incrementing index 0
 Pattern update (should be the same as before)
 Incrementing index 0
-t=1000: Handling entry event packetin(1) at switch 0
+t=1000: Handling entry event packetin(1) at switch 0, port 0
 Incrementing index 1
 Pattern update (should be the same as before)
 Incrementing index 1
-t=2000: Handling entry event packetin(2) at switch 0
+t=2000: Handling entry event packetin(2) at switch 0, port 0
 Incrementing index 2
 Pattern update (should be the same as before)
 Incrementing index 2
-t=3000: Handling entry event packetin(3) at switch 0
+t=3000: Handling entry event packetin(3) at switch 0, port 0
 Incrementing index 4
 Pattern update (should be the same as before)
 Incrementing index 4
-t=4000: Handling entry event packetin(4) at switch 0
+t=4000: Handling entry event packetin(4) at switch 0, port 0
 Incrementing index 2
 Pattern update (should be the same as before)
 Incrementing index 2
-t=5000: Handling entry event packetin(5) at switch 0
+t=5000: Handling entry event packetin(5) at switch 0, port 0
 Incrementing index 3
 Pattern update (should be the same as before)
 Incrementing index 3
-t=6000: Handling entry event packetin(6) at switch 0
+t=6000: Handling entry event packetin(6) at switch 0, port 0
 Incrementing index 2
 Pattern update (should be the same as before)
 Incrementing index 2
-t=7000: Handling entry event packetin(7) at switch 0
+t=7000: Handling entry event packetin(7) at switch 0, port 0
 Incrementing index 3
 Pattern update (should be the same as before)
 Incrementing index 3
-t=8000: Handling entry event packetin(0) at switch 0
+t=8000: Handling entry event packetin(0) at switch 0, port 0
 Incrementing index 0
 Pattern update (should be the same as before)
 Incrementing index 0

--- a/test/expected/module_output.txt
+++ b/test/expected/module_output.txt
@@ -3,12 +3,12 @@ dpt: Auto-detected specification file examples/interp_tests/module.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling event update_both(0,1) at switch 0
-t=10000: Handling event update_both(1,1) at switch 0
-t=20000: Handling event update_both(2,1) at switch 0
-t=30000: Handling event update_both(3,1) at switch 0
-t=40000: Handling event update_both(4,1) at switch 0
-t=50000: Handling event update_both(5,1) at switch 0
+t=0: Handling event update_both(0,1) at switch 0, port 0
+t=10000: Handling event update_both(1,1) at switch 0, port 0
+t=20000: Handling event update_both(2,1) at switch 0, port 0
+t=30000: Handling event update_both(3,1) at switch 0, port 0
+t=40000: Handling event update_both(4,1) at switch 0, port 0
+t=50000: Handling event update_both(5,1) at switch 0, port 0
 dpt: Final State:
 
 Switch 0 : {

--- a/test/expected/operators_output.txt
+++ b/test/expected/operators_output.txt
@@ -3,35 +3,35 @@ dpt: Auto-detected specification file examples/interp_tests/operators.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling event in(0,0) at switch 0
+t=0: Handling event in(0,0) at switch 0, port 0
 i < j: false. i > j: false. i <= j: true. i >= j: true. i == j: true. i != j: false
 i + j = 0. i - j = 0. i |-| j = 0. i & j = 0. i | j = 0. i <<< j = 0. i >>> j = 0. i ^ j = 0
 i[7:0] = 0. i[4:2] = 0. i[5:3] = 0. i[0:0] = 0
-t=1000: Handling event in(1,0) at switch 0
+t=1000: Handling event in(1,0) at switch 0, port 0
 i < j: false. i > j: true. i <= j: false. i >= j: true. i == j: false. i != j: true
 i + j = 1. i - j = 1. i |-| j = 1. i & j = 0. i | j = 1. i <<< j = 1. i >>> j = 1. i ^ j = 256
 i[7:0] = 1. i[4:2] = 0. i[5:3] = 0. i[0:0] = 1
-t=2000: Handling event in(0,1) at switch 0
+t=2000: Handling event in(0,1) at switch 0, port 0
 i < j: true. i > j: false. i <= j: true. i >= j: false. i == j: false. i != j: true
 i + j = 1. i - j = 255. i |-| j = 0. i & j = 0. i | j = 1. i <<< j = 0. i >>> j = 0. i ^ j = 1
 i[7:0] = 0. i[4:2] = 0. i[5:3] = 0. i[0:0] = 0
-t=3000: Handling event in(30,15) at switch 0
+t=3000: Handling event in(30,15) at switch 0, port 0
 i < j: false. i > j: true. i <= j: false. i >= j: true. i == j: false. i != j: true
 i + j = 45. i - j = 15. i |-| j = 15. i & j = 14. i | j = 31. i <<< j = 0. i >>> j = 0. i ^ j = 7695
 i[7:0] = 30. i[4:2] = 7. i[5:3] = 3. i[0:0] = 0
-t=4000: Handling event in(63,1) at switch 0
+t=4000: Handling event in(63,1) at switch 0, port 0
 i < j: false. i > j: true. i <= j: false. i >= j: true. i == j: false. i != j: true
 i + j = 64. i - j = 62. i |-| j = 62. i & j = 1. i | j = 63. i <<< j = 126. i >>> j = 31. i ^ j = 16129
 i[7:0] = 63. i[4:2] = 7. i[5:3] = 7. i[0:0] = 1
-t=5000: Handling event in(63,2) at switch 0
+t=5000: Handling event in(63,2) at switch 0, port 0
 i < j: false. i > j: true. i <= j: false. i >= j: true. i == j: false. i != j: true
 i + j = 65. i - j = 61. i |-| j = 61. i & j = 2. i | j = 63. i <<< j = 252. i >>> j = 15. i ^ j = 16130
 i[7:0] = 63. i[4:2] = 7. i[5:3] = 7. i[0:0] = 1
-t=6000: Handling event in(63,3) at switch 0
+t=6000: Handling event in(63,3) at switch 0, port 0
 i < j: false. i > j: true. i <= j: false. i >= j: true. i == j: false. i != j: true
 i + j = 66. i - j = 60. i |-| j = 60. i & j = 3. i | j = 63. i <<< j = 248. i >>> j = 7. i ^ j = 16131
 i[7:0] = 63. i[4:2] = 7. i[5:3] = 7. i[0:0] = 1
-t=7000: Handling event in(63,20) at switch 0
+t=7000: Handling event in(63,20) at switch 0, port 0
 i < j: false. i > j: true. i <= j: false. i >= j: true. i == j: false. i != j: true
 i + j = 83. i - j = 43. i |-| j = 43. i & j = 20. i | j = 63. i <<< j = 0. i >>> j = 0. i ^ j = 16148
 i[7:0] = 63. i[4:2] = 7. i[5:3] = 7. i[0:0] = 1

--- a/test/expected/return_test_output.txt
+++ b/test/expected/return_test_output.txt
@@ -3,14 +3,14 @@ dpt: Auto-detected specification file examples/interp_tests/return_test.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling event in(true,true,true) at switch 0
-t=10000: Handling event in(true,true,false) at switch 0
-t=20000: Handling event in(true,false,true) at switch 0
-t=30000: Handling event in(true,false,false) at switch 0
-t=40000: Handling event in(false,true,true) at switch 0
-t=50000: Handling event in(false,true,false) at switch 0
-t=60000: Handling event in(false,false,true) at switch 0
-t=70000: Handling event in(false,false,false) at switch 0
+t=0: Handling event in(true,true,true) at switch 0, port 0
+t=10000: Handling event in(true,true,false) at switch 0, port 0
+t=20000: Handling event in(true,false,true) at switch 0, port 0
+t=30000: Handling event in(true,false,false) at switch 0, port 0
+t=40000: Handling event in(false,true,true) at switch 0, port 0
+t=50000: Handling event in(false,true,false) at switch 0, port 0
+t=60000: Handling event in(false,false,true) at switch 0, port 0
+t=70000: Handling event in(false,false,false) at switch 0, port 0
 dpt: Final State:
 
 Switch 0 : {
@@ -23,8 +23,8 @@ Switch 0 : {
  Events :   [ ]
 
  Exits :    [
-    out(true,true,true) at t=0
-    out(false,true,true) at t=40000
+    out(true,true,true) at port -1, t=0
+    out(false,true,true) at port -1, t=40000
   ]
 
  entry events handled: 0

--- a/test/expected/symbolics0_output.txt
+++ b/test/expected/symbolics0_output.txt
@@ -4,7 +4,7 @@ dpt: Auto-detected specification file examples/interp_tests/symbolics0.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling event in(0) at switch 0
+t=0: Handling event in(0) at switch 0, port 0
 dpt: Final State:
 
 Switch 0 : {

--- a/test/expected/symbolics_output.txt
+++ b/test/expected/symbolics_output.txt
@@ -4,7 +4,7 @@ dpt: Auto-detected specification file examples/interp_tests/symbolics.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling event in(0) at switch 0
+t=0: Handling event in(0) at switch 0, port 0
 dpt: Final State:
 
 Switch 0 : {

--- a/test/expected/user_types_output.txt
+++ b/test/expected/user_types_output.txt
@@ -3,12 +3,12 @@ dpt: Auto-detected specification file examples/interp_tests/user_types.json
 dpt: Simulating...
 dpt: Using random seed: 0
 
-t=0: Handling event update_both(0,1) at switch 0
-t=10000: Handling event update_both(1,1) at switch 0
-t=20000: Handling event update_both(2,1) at switch 0
-t=30000: Handling event update_both(3,1) at switch 0
-t=40000: Handling event update_both(4,1) at switch 0
-t=50000: Handling event update_both(5,1) at switch 0
+t=0: Handling event update_both(0,1) at switch 0, port 0
+t=10000: Handling event update_both(1,1) at switch 0, port 0
+t=20000: Handling event update_both(2,1) at switch 0, port 0
+t=30000: Handling event update_both(3,1) at switch 0, port 0
+t=40000: Handling event update_both(4,1) at switch 0, port 0
+t=50000: Handling event update_both(5,1) at switch 0, port 0
 dpt: Final State:
 
 Switch 0 : {

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -1,20 +1,6 @@
 import subprocess, os, filecmp
 
-interpfiles = [
-"basics",
-"NAT",
-"chain_stateful_firewall",
-"match",
-"global_args",
-"return_test",
-"user_types",
-"module",
-"operators",
-"BloomFilter",
-"symbolics",
-"symbolics0"
-]
-
+interpfiles = [x for x in os.listdir("examples/interp_tests/") if x.endswith(".dpt")]
 libraryfiles = [x for x in os.listdir("examples/library/") if x.endswith(".dpt")]
 regressionfiles = [x for x in os.listdir("examples/regression/") if x.endswith(".dpt")]
 poplfiles = [x for x in os.listdir("examples/popl22/") if x.endswith(".dpt")]
@@ -25,17 +11,18 @@ diffs = []
 if not (os.path.isdir("test/output")):
     os.mkdir("test/output")
 
-def interp_test(file, args):
-    print("Running test on "+file)
-    outname = "{}_output.txt".format(file)
+def interp_test(fullfile, args):
+    shortfile = fullfile[0:-4]
+    print("Running test on "+shortfile)
+    outname = "{}_output.txt".format(shortfile)
     with open("test/output/"+outname, "w") as outfile:
-        fullfile = "examples/interp_tests/"+file+".dpt"
+        fullfile = "examples/interp_tests/"+fullfile
         cmd = ["./dpt", "--silent", fullfile] + args
         ret = subprocess.run(cmd, stdout=outfile, stderr=subprocess.DEVNULL)
     if ret.returncode != 0:
         errors.append(fullfile)
     elif not filecmp.cmp("test/output/"+outname, "test/expected/"+outname):
-        diffs.append(file)
+        diffs.append(shortfile)
     outfile.close()
 
 def just_typecheck(path, file, suffix = ""):


### PR DESCRIPTION
This PR adds support for ports and network topologies to Lucid. Note that this PR is not backwards-compatible; instructions of updating existing code can be found at the bottom of this PR. 
### Changelog:
* Each handler now has an automatically-defined variable named `ingress_port`, which is the port the event entered on.
* Each switch now has an automatically-defined top-level variable named `recirculation_port` which is the current switch's recirculation port; this defaults to 196, but can be set in the interpreter specification file.
* Multicast groups now represent sets of ports, rather than sets of switch ids. Furthermore, groups no longer need to be declared ahead-of-time (though their entries must still be integer literals).
* The expression `flood e` returns a multicast group which includes every port except `e`. Unlike constant groups, `e` is allowed to be a variable (e.g. `flood port_id` is allowed).
* The topology must be specified in the interpreter specification file if the network has more than one switch. The specification should either be the string "full mesh", in which case all switches will be connected (used arbitrary port numbers), or a list of "switch_id:port_id" pairs. Event locations in the spec file should also have the latter form. For examples, see `examples/interp_tests/bouncing.json` and `examples/interp_tests/chain_stateful_firewall.json`
* We have removed the `Event.locate` combinators; instead, locations must be specified as part of the generate function. This also means that there is no longer a distinction between the types `event` and `mevent`. There are now three types of generate statement (with `generate` remaining as syntactic sugar); for details, see https://github.com/PrincetonUniversity/lucid/wiki/Language-Features#event-generation.
### Updating old code
1. For each `group` declaration, add the keyword `const` before it (e.g. `group foo = {0, 1};` -> `const group foo = {0, 1};`).
    i. If you prefer, you may also eliminate the group declaration entirely, and replace all uses of `foo` with `{0, 1}`. The two options are equivalent.
3. For each `mevent` type in your program, change it to `event`, and change any calls to `Event.mdelay` to `Event.delay`.
2. For each `generate` statement:
    i. If the event was never located with an `Event.locate`, you don't need to change anything.
    ii. If the event was ever located with `Event.locate`, determine the most recent call `Event.xxlocate(event, loc)` and change the generate statement to `generate_switch (loc, event);`
4. For each `mgenerate` statement in your program, follow the instructions in (2.ii) above, except use `generate_ports` instead of `generate_switch`
5. Remove any remaining calls to `Event.locate`.