### PR TITLE
Big memops

### DIFF
--- a/examples/interp_tests/pairarrays.dpt
+++ b/examples/interp_tests/pairarrays.dpt
@@ -1,0 +1,49 @@
+// Note: All logic in this file is completely made up, don't try to figure out
+// what it's trying to do
+
+global PairArray.t<<16>> g1 = PairArray.create(4);
+global PairArray.t<<8>>  g2 = PairArray.create(4);
+global Array.t<<16>>     g3 = Array.create(4);
+
+memop twoarg(int<<'a>> memval1, int<<'a>> localval1) {
+  return memval1 + localval1 + 1;
+}
+
+memop fourarg(int<<'a>> memval1, int<<'a>> memval2, int<<'a>> localval1, int<<'a>> localval2) {
+  bool b1 = memval1 + localval1 < 3;
+  bool b2 = memval2 > localval1 + 7;
+
+    if (b1 && b2)          { cell1 = memval2 + localval2; } else
+  { if (!b1 || !b2)        { cell1 = memval1 + 2; } }
+
+    if ((b1 && !b2) || b2) { cell2 = memval2 + 1; } else
+  { if (!b1 || b2)         { cell2 = memval2 + localval1; } }
+
+    if (b1) { return memval1 + localval2 + 3 + 8; }
+}
+
+memop threearg(int<<'a>> memval1, int<<'a>> localval1, int<<'a>> localval2) {
+  bool b1 = memval1 + localval1 < 3;
+  bool b2 = memval1 > localval1 + 7;
+
+    if (b1 && b2)          { cell1 = memval1 + localval2; } else
+  { if (!b1 || !b2)        { cell1 = memval1 + 2; } }
+
+    if ((b1 && !b2) || b2) { cell2 = memval1 + 1; } else
+  { if (!b1 || b2)         { cell2 = memval1 + localval1; } }
+
+    if (b1 || !b2) { return cell2; }
+}
+
+event in(int idx, int<<16>> i, int<<16>> j) {
+  int<<16>> x = PairArray.update(g1, idx, fourarg, i, j, 0);
+  int<<8>> y = PairArray.update(g2, idx, fourarg, (int<<8>>)i, (int<<8>>)j, 0);
+  int<<16>> z = 0;
+  if (idx < 2) {
+    z = Array.update(g3, idx, twoarg, i, twoarg, j);
+  } else {
+    z = Array.update_complex(g3, idx, threearg, i, j, 0);
+  }
+
+  printf("%d, %d, %d", x, y, z);
+}

--- a/examples/interp_tests/pairarrays.json
+++ b/examples/interp_tests/pairarrays.json
@@ -1,0 +1,16 @@
+{
+  "switches": 1,
+  "max time": 9999999,
+  "default input gap": 1000,
+  "random seed": 0,
+  "events": [
+    {"name":"in", "args": [0, 2, 7]},
+    {"name":"in", "args": [1, 1, 2]},
+    {"name":"in", "args": [2, 4, 1]},
+    {"name":"in", "args": [3, 30, 15]},
+    {"name":"in", "args": [1, 63, 1]},
+    {"name":"in", "args": [2, 63, 2]},
+    {"name":"in", "args": [3, 63, 3]},
+    {"name":"in", "args": [0, 63, 20]}
+  ]
+}

--- a/examples/interp_tests/symbolics.dpt
+++ b/examples/interp_tests/symbolics.dpt
@@ -7,7 +7,7 @@ symbolic bool b;
 
 global Array.t<<a>>[b] arrs = [Array.create(n1) for i < b];
 
-memop add(int<<'a>> x, int <<'b>> y) {
+memop add(int<<'a>> x, int <<'a>> y) {
   return x + y;
 }
 

--- a/examples/interp_tests/symbolics0.dpt
+++ b/examples/interp_tests/symbolics0.dpt
@@ -7,7 +7,7 @@ symbolic bool b;
 
 global Array.t<<a>>[b] arrs = [Array.create(n1) for i < b];
 
-memop add(int<<'a>> x, int <<'b>> y) {
+memop add(int<<'a>> x, int <<'a>> y) {
   return x + y;
 }
 

--- a/examples/library/Memops.dpt
+++ b/examples/library/Memops.dpt
@@ -1,7 +1,7 @@
 /** A bunch of generically useful memop definitions **/
 
 // Return the first argument
-memop fst(int<<'a>> x, int<<'b>> y) { return x; }
+memop fst(int<<'a>> x, int<<'a>> y) { return x; }
 
 // Return the second argument
 memop snd(int<<'a>> x, int<<'a>> y) { return y; }
@@ -25,6 +25,6 @@ memop min(int<<'a>> x, int<<'a>> y) {
 }
 
 // Add 1 to the first argument
-memop incr(int<<'a>> x, int<<'b>> y) {
+memop incr(int<<'a>> x, int<<'a>> y) {
   return x + 1;
 }

--- a/examples/library/SafeArray.dpt
+++ b/examples/library/SafeArray.dpt
@@ -14,8 +14,8 @@ module SafeArray {
   };
 
   fun int<<'b>> update(t<<'a>> arr, int idx,
-                       memop<<'a, 'b>> getop, int<<'b>> getarg,
-                       memop<<'a, 'a>> setop, int<<'a>> setarg)
+                       memop2<<'a>> getop, int<<'a>> getarg,
+                       memop2<<'a>> setop, int<<'a>> setarg)
   {
     if (idx >= 0 && idx < arr#sz) {
       return Array.update(arr#arr, idx, getop, getarg, setop, setarg);
@@ -31,11 +31,11 @@ module SafeArray {
     update(arr, idx, fst, 0, snd, v);
   }
 
-  fun int<<'b>> getm(t<<'a>> arr, int idx, memop<<'a, 'b>> getop, int<<'b>> getarg) {
+  fun int<<'b>> getm(t<<'a>> arr, int idx, memop2<<'a>> getop, int<<'b>> getarg) {
     return update(arr, idx, getop, getarg, fst, 0);
   }
 
-  fun void setm(t<<'a>> arr, int idx, memop<<'a, 'a>> setop, int<<'a>> setarg) {
+  fun void setm(t<<'a>> arr, int idx, memop2<<'a>> setop, int<<'a>> setarg) {
     update(arr, idx, fst, 0, setop, setarg);
   }
 

--- a/examples/popl22/Memops.dpt
+++ b/examples/popl22/Memops.dpt
@@ -1,7 +1,7 @@
 /** A bunch of generically useful memop definitions **/
 
 // Return the first argument
-memop fst(int<<'a>> x, int<<'b>> y) { return x; }
+memop fst(int<<'a>> x, int<<'a>> y) { return x; }
 
 // Return the second argument
 memop snd(int<<'a>> x, int<<'a>> y) { return y; }
@@ -53,6 +53,6 @@ memop leq(int<<'a>> x, int<<'a>> y) {
 */
 
 // Add 1 to the first argument
-memop incr(int<<'a>> x, int<<'b>> y) {
+memop incr(int<<'a>> x, int<<'a>> y) {
   return x + 1;
 }

--- a/src/lib/backend/LLTranslate/LLContext.ml
+++ b/src/lib/backend/LLTranslate/LLContext.ml
@@ -4,9 +4,9 @@ open Batteries
 module CL = Caml.List
 open InterpHelpers
 
-
 (* logging *)
 module DBG = BackendLogging
+
 let outc = ref None
 let dprint_endline = ref DBG.no_printf
 let start_logging () = DBG.start_mlog __FILE__ outc dprint_endline
@@ -80,17 +80,20 @@ let ctx_find_decl_opt n =
 let ctx_add_decls (ds : decls) =
   let iter_f dec =
     match dec.d with
-    | DGlobal (id, _, _) | DMemop (id, _) -> ctx_add_decl (Cid.id id) dec
+    | DGlobal (id, _, _) | DMemop (id, _, _) -> ctx_add_decl (Cid.id id) dec
     | _ -> ()
   in
   CL.iter iter_f ds
 ;;
 
 let ctx_bdy_of_memop n =
-  match ctx_find_decl n with
-  | { d = DMemop (_, (params, stmt)); _ } -> cids_from_params params, stmt
-  | _ -> error "could not find memop in decl context"
+  ignore n;
+  failwith "New memops not yet implemented in the backend!"
 ;;
+
+(* match ctx_find_decl n with
+  | { d = DMemop (_, (params, stmt)); _ } -> cids_from_params params, stmt
+  | _ -> error "could not find memop in decl context" *)
 
 let ctx_width_of_garr n =
   match ctx_find_decl n with
@@ -104,9 +107,7 @@ let ctx_width_of_garr n =
 ;;
 
 (**** context code generator functions ****)
-let ctx_add_codegen n c =
-  tofinoCtx := TofinoCtx.add n (CodeGen c) !tofinoCtx
-;;
+let ctx_add_codegen n c = tofinoCtx := TofinoCtx.add n (CodeGen c) !tofinoCtx
 
 let ctx_add_codegens ns_cs =
   let iter_f (n, c) = ctx_add_codegen n c in
@@ -131,17 +132,17 @@ let ctx_add_erec erec =
   tofinoCtx := TofinoCtx.add key entry !tofinoCtx
 ;;
 
-let ctx_find_eventrec (cid: Cid.t) =
+let ctx_find_eventrec (cid : Cid.t) =
   match TofinoCtx.find cid !tofinoCtx with
   | EventRec r -> r
   | _ -> error "did not find event rec in context"
 ;;
 
-let ctx_find_eventrec_opt (cid: Cid.t) =
+let ctx_find_eventrec_opt (cid : Cid.t) =
   match TofinoCtx.find_opt cid !tofinoCtx with
   | Some (EventRec r) -> Some r
-  | Some (_) -> None
-  | None -> None 
+  | Some _ -> None
+  | None -> None
 ;;
 
 let ctx_find_event_fields id =

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -38,7 +38,7 @@
    typerUtil
    typerInstGen
    typerModules
-   typerMemops
+   memops
    wellformed
    functionInlining
    functionInliningSpecialCase

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -38,6 +38,7 @@
    typerUtil
    typerInstGen
    typerModules
+   typerMemops
    wellformed
    functionInlining
    functionInliningSpecialCase

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -68,6 +68,7 @@
    interpState
    arrays
    counters
+   pairArrays
    system
    events
    builtins

--- a/src/lib/frontend/Console.ml
+++ b/src/lib/frontend/Console.ml
@@ -27,41 +27,38 @@ let error msg =
 let warning msg = show_message msg T.Yellow "warning"
 let report msg = show_message msg T.Black "dpt"
 
-let read_files fnames : unit =
-  let read_one_file fname =
-    let lines = ref [] in
-    let indices = ref [] in
-    let index = ref 0 in
-    let chan =
-      try open_in fname with
-      | _ -> error (Printf.sprintf "file '%s' not found" fname)
-    in
-    try
-      while true do
-        let line = input_line chan in
-        (* print_endline @@ "Line:" ^ line; *)
-        let len = String.length line in
-        let new_len = !index + len + 1 in
-        indices := (!index, new_len) :: !indices;
-        index := new_len;
-        lines := line :: !lines
-      done;
-      { input = Array.of_list !lines; linenums = Array.of_list !indices }
-    with
-    | End_of_file ->
-      close_in chan;
-      { input = Array.of_list (List.rev !lines)
-      ; linenums = Array.of_list (List.rev !indices)
-      }
+let read_one_file fname =
+  let lines = ref [] in
+  let indices = ref [] in
+  let index = ref 0 in
+  let chan =
+    try open_in fname with
+    | _ -> error (Printf.sprintf "file '%s' not found" fname)
   in
-  let info =
-    List.fold_left
-      (fun acc fname -> StringMap.add fname (read_one_file fname) acc)
-      StringMap.empty
-      fnames
-  in
-  global_info := info
+  try
+    while true do
+      let line = input_line chan in
+      (* print_endline @@ "Line:" ^ line; *)
+      let len = String.length line in
+      let new_len = !index + len + 1 in
+      indices := (!index, new_len) :: !indices;
+      index := new_len;
+      lines := line :: !lines
+    done;
+    { input = Array.of_list !lines; linenums = Array.of_list !indices }
+  with
+  | End_of_file ->
+    close_in chan;
+    { input = Array.of_list (List.rev !lines)
+    ; linenums = Array.of_list (List.rev !indices)
+    }
 ;;
+
+let read_file fname : unit =
+  global_info := StringMap.add fname (read_one_file fname) !global_info
+;;
+
+let read_files fnames : unit = List.iter read_file fnames
 
 let get_position_opt fname idx =
   if fname = ""

--- a/src/lib/frontend/Console.mli
+++ b/src/lib/frontend/Console.mli
@@ -2,7 +2,9 @@ module T = ANSITerminal
 
 exception Error of string
 
-(* read_files initializes info about the input files for position printing *)
+(* Initialize info about the input files for position printing.
+   Can be called incrementally. *)
+val read_file : string -> unit
 val read_files : string list -> unit
 val error : string -> 'a
 val warning : string -> unit

--- a/src/lib/frontend/Lexer.mll
+++ b/src/lib/frontend/Lexer.mll
@@ -49,7 +49,8 @@ rule token = parse
   | "printf"          { PRINTF (position lexbuf) }
   | "handle"	        { HANDLE (position lexbuf) }
   | "fun"             { FUN (position lexbuf)}
-  | "memop"           { MEMOP (position lexbuf)}
+  | "memop"(num as n) { MEMOP (position lexbuf, Int.of_string n) }
+  | "memop"           { MEMOP (position lexbuf, 0) }
   | "return"          { RETURN (position lexbuf)}
   | "size"            { SIZE (position lexbuf) }
   | "global"          { GLOBAL (position lexbuf) }

--- a/src/lib/frontend/Memops.ml
+++ b/src/lib/frontend/Memops.ml
@@ -53,7 +53,8 @@ let check_e memvars localvars allowed_op exp =
       else
         error_sp
           e.espan
-          ("Disallowed operation in memop expression" ^ Printing.exp_to_string e)
+          ("Disallowed operation in memop expression: "
+          ^ Printing.exp_to_string e)
     | _ ->
       error_sp
         e.espan
@@ -122,7 +123,7 @@ let check_conditional param_ids e =
 
 let extract_simple_body mem1 local1 body =
   let check_int = check_int_exp [mem1] [local1] in
-  let check_bool = check_int_exp [mem1] [local1] in
+  let check_bool = check_bool_exp [mem1] [local1] in
   match flatten_stmt body with
   | [{ s = SRet (Some e) }] ->
     check_int e;

--- a/src/lib/frontend/Memops.ml
+++ b/src/lib/frontend/Memops.ml
@@ -126,14 +126,14 @@ let extract_simple_body mem1 local1 body =
   match flatten_stmt body with
   | [{ s = SRet (Some e) }] ->
     check_int e;
-    SBReturn e
+    MBReturn e
   | [{ s = SIf (e, s1, s2) }] ->
     check_bool e;
     (match flatten_stmt s1, flatten_stmt s2 with
     | [{ s = SRet (Some e1) }], [{ s = SRet (Some e2) }] ->
       check_int e1;
       check_int e2;
-      SBIf (e, e1, e2)
+      MBIf (e, e1, e2)
     | _ ->
       error_sp body.sspan "Invalid if statement in a memop with two arguments")
   | _ -> error_sp body.sspan "Invalid form for a memop with two arguments"
@@ -297,10 +297,10 @@ let extract_memop span (params : params) (body : statement) : memop_body =
       then error_sp span "Arguments to a memop may not be named cell1 or cell2")
     params;
   match params with
-  | [(mem1, _); (local1, _)] -> TwoArg (extract_simple_body mem1 local1 body)
+  | [(mem1, _); (local1, _)] -> extract_simple_body mem1 local1 body
   | [(mem1, _); (local1, _); (local2, _)] ->
-    ThreeArg (extract_complex_body [mem1] [local1; local2] body)
+    MBComplex (extract_complex_body [mem1] [local1; local2] body)
   | [(mem1, _); (mem2, _); (local1, _); (local2, _)] ->
-    FourArg (extract_complex_body [mem1; mem2] [local1; local2] body)
+    MBComplex (extract_complex_body [mem1; mem2] [local1; local2] body)
   | _ -> error_sp span "A memop must have exactly 2, 3, or 4 arguments"
 ;;

--- a/src/lib/frontend/Memops.ml
+++ b/src/lib/frontend/Memops.ml
@@ -271,7 +271,7 @@ let ensure_same_size span params =
   let sizes =
     List.map
       (fun (_, ty) ->
-        match ty.raw_ty with
+        match TyTQVar.strip_links ty.raw_ty with
         | TInt sz -> sz
         | _ ->
           Console.error_position
@@ -302,5 +302,5 @@ let extract_memop span (params : params) (body : statement) : memop_body =
     ThreeArg (extract_complex_body [mem1] [local1; local2] body)
   | [(mem1, _); (mem2, _); (local1, _); (local2, _)] ->
     FourArg (extract_complex_body [mem1; mem2] [local1; local2] body)
-  | _ -> failwith ""
+  | _ -> error_sp span "A memop must have exactly 2, 3, or 4 arguments"
 ;;

--- a/src/lib/frontend/Memops.ml
+++ b/src/lib/frontend/Memops.ml
@@ -65,7 +65,7 @@ let check_e memvars localvars allowed_op exp =
 ;;
 
 let allowed_bool_op = function
-  | Eq | Neq | Less | More -> true
+  | Eq | Neq | Less | More | And | Or | Not -> true
   | _ -> false
 ;;
 
@@ -104,6 +104,7 @@ let check_conditional param_ids e =
       if not (allowed_var cid)
       then
         error_sp e.espan "Disallowed variable in memop conditional expression"
+    | EOp (Not, [e1]) -> aux e1
     | EOp (op, [e1; e2]) ->
       if not (allowed_bool_op op)
       then

--- a/src/lib/frontend/Parser.mly
+++ b/src/lib/frontend/Parser.mly
@@ -17,6 +17,10 @@
     | [s1; s2] -> TMemop (s1, s2)
     | _ -> Console.error_position span "Wrong number of size arguments to memop"
 
+  let mk_dmemop id params body span =
+    memop_sp id params (Memops.extract_memop span params body) span
+  ;;
+
   (* We can't use Id.fresh for auto because it messes with regular ids *)
   let auto_count = ref (-1)
   let fresh_auto () =
@@ -327,7 +331,7 @@ decl:
     | FUN ty ID paramsdef constr_list LBRACE statement RBRACE
                                             { [fun_sp (snd $3) $2 $5 $4 $7 (Span.extend $1 $8)] }
     | MEMOP ID paramsdef LBRACE statement RBRACE
-                                            { [memop_sp (snd $2) $3 $5 (Span.extend $1 $6)] }
+                                            { [mk_dmemop (snd $2) $3 $5 (Span.extend $1 $6)] }
     | SYMBOLIC SIZE ID SEMI                 { [dsize_sp (snd $3) None (Span.extend $1 $4)] }
     | SIZE ID ASSIGN size SEMI              { [dsize_sp (snd $2) (Some (snd $4)) (Span.extend $1 $5)] }
     | MODULE ID LBRACE decls RBRACE         { [module_sp (snd $2) [] $4 (Span.extend $1 $5)] }

--- a/src/lib/frontend/Printing.ml
+++ b/src/lib/frontend/Printing.ml
@@ -422,6 +422,8 @@ let rec interface_spec_to_string spec =
 and interface_to_string specs =
   "{\n" ^ concat_map "\n\n" interface_spec_to_string specs ^ "\n}\n"
 
+and memop_to_string body = stmt_to_string (memop_body_to_stmt body)
+
 and d_to_string d =
   match d with
   | DGlobal (id, ty, exp) ->
@@ -451,12 +453,12 @@ and d_to_string d =
       (params_to_string params)
       (cspecs_to_string cspecs)
       (stmt_to_string s)
-  | DMemop (id, (params, s)) ->
+  | DMemop (id, params, mbody) ->
     Printf.sprintf
       "memop %s(%s)\n {%s}"
       (id_to_string id)
       (params_to_string params)
-      (stmt_to_string s)
+      (memop_to_string mbody)
   | DSize (id, szo) ->
     begin
       match szo with

--- a/src/lib/frontend/Printing.ml
+++ b/src/lib/frontend/Printing.ml
@@ -136,11 +136,7 @@ let rec raw_ty_to_string t =
     ^ if cfg.verbose_types then "{" ^ string_of_bool b ^ "}" else ""
   | TEvent -> "event"
   | TFun func -> func_to_string func
-  | TMemop (size1, size2) ->
-    Printf.sprintf
-      "memop[int<<%s>>, %s]"
-      (size_to_string size1)
-      (size_to_string size2)
+  | TMemop (n, size) -> Printf.sprintf "memop%d<<%s>>" n (size_to_string size)
   | TVoid -> "void"
   | TGroup -> "group"
   | TRecord lst ->

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -49,7 +49,7 @@ and raw_ty =
   | TInt of size (* Number of bits *)
   | TEvent
   | TFun of func_ty
-  | TMemop of size * size
+  | TMemop of int (* Number of arguments: 2-4 *) * size
   | TName of cid * sizes * bool (* Named type: e.g. "Array.t<<32>>". Bool is true if it represents a global type *)
   | TAbstract of cid * sizes * bool * raw_ty (* raw_ty is the type when it was a TName *)
   | TRecord of (string * raw_ty) list

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -204,6 +204,26 @@ and interface_spec =
 
 and interface = interface_spec list
 
+(* For memops -- Boolean condition * return value *)
+and conditional_return = exp * exp
+
+and simple_body =
+  | SBReturn of exp
+  | SBIf of exp * exp * exp
+
+and complex_body =
+  { b1 : (id * exp) option
+  ; b2 : (id * exp) option
+  ; cell1 : conditional_return option * conditional_return option
+  ; cell2 : conditional_return option * conditional_return option
+  ; ret : conditional_return option
+  }
+
+and memop_body =
+  | TwoArg of simple_body
+  | ThreeArg of complex_body
+  | FourArg of complex_body
+
 (* declarations *)
 and d =
   | DSize of id * size option
@@ -211,7 +231,7 @@ and d =
   | DEvent of id * event_sort * constr_spec list * params
   | DHandler of id * body
   | DFun of id * ty * constr_spec list * body
-  | DMemop of id * body
+  | DMemop of id * params * memop_body
   | DConst of id * ty * exp
   | DExtern of id * ty
   | DSymbolic of id * ty
@@ -365,7 +385,7 @@ let dsymbolic_sp id ty span = decl_sp (DSymbolic (id, ty)) span
 let handler_sp id p body span = decl_sp (DHandler (id, (p, body))) span
 let dsize_sp id size span = decl_sp (DSize (id, size)) span
 let fun_sp id rty cs p body span = decl_sp (DFun (id, rty, cs, (p, body))) span
-let memop_sp id p body span = decl_sp (DMemop (id, (p, body))) span
+let memop_sp id p body span = decl_sp (DMemop (id, p, body)) span
 let duty_sp id sizes rty span = decl_sp (DUserTy (id, sizes, rty)) span
 
 let dconstr_sp id ty params exp span =

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -207,10 +207,6 @@ and interface = interface_spec list
 (* For memops -- Boolean condition * return value *)
 and conditional_return = exp * exp
 
-and simple_body =
-  | SBReturn of exp
-  | SBIf of exp * exp * exp
-
 and complex_body =
   { b1 : (id * exp) option
   ; b2 : (id * exp) option
@@ -220,9 +216,9 @@ and complex_body =
   }
 
 and memop_body =
-  | TwoArg of simple_body
-  | ThreeArg of complex_body
-  | FourArg of complex_body
+  | MBReturn of exp
+  | MBIf of exp * exp * exp
+  | MBComplex of complex_body
 
 (* declarations *)
 and d =

--- a/src/lib/frontend/SyntaxUtils.ml
+++ b/src/lib/frontend/SyntaxUtils.ml
@@ -312,3 +312,14 @@ let rec is_compound e =
   | EWith (base, entries) ->
     is_compound base || List.exists (is_compound % snd) entries
 ;;
+
+(* Turn a SSeq into a list of statements. Only applies to top-level SSeqs *)
+let flatten_stmt s =
+  let rec aux acc s =
+    match s.s with
+    | SNoop -> acc
+    | SSeq (s1, s2) -> aux (aux acc s2) s1
+    | _ -> s :: acc
+  in
+  aux [] s
+;;

--- a/src/lib/frontend/SyntaxUtils.ml
+++ b/src/lib/frontend/SyntaxUtils.ml
@@ -222,8 +222,7 @@ let rec equiv_raw_ty ?(ignore_effects = false) ?(qvars_wild = false) ty1 ty2 =
   match ty1, ty2 with
   | TBool, TBool | TVoid, TVoid | TGroup, TGroup | TEvent, TEvent -> true
   | TInt size1, TInt size2 -> equiv_size size1 size2
-  | TMemop (size1, size2), TMemop (size3, size4) ->
-    equiv_size size1 size3 && equiv_size size2 size4
+  | TMemop (n1, size1), TMemop (n2, size2) -> n1 = n2 && equiv_size size1 size2
   | TName (id1, sizes1, b1), TName (id2, sizes2, b2)
   | TAbstract (id1, sizes1, b1, _), TAbstract (id2, sizes2, b2, _) ->
     b1 = b2 && Cid.equal id1 id2 && List.for_all2 equiv_size sizes1 sizes2

--- a/src/lib/frontend/SyntaxUtils.ml
+++ b/src/lib/frontend/SyntaxUtils.ml
@@ -334,13 +334,6 @@ let flatten_stmt s =
 
 (* Mostly useful for printing *)
 
-let simple_body_to_stmt (body : simple_body) =
-  match body with
-  | SBReturn e -> statement (SRet (Some e))
-  | SBIf (e1, e2, e3) ->
-    sifte e1 (statement (SRet (Some e2))) (statement (SRet (Some e3)))
-;;
-
 let complex_body_to_stmt (body : complex_body) =
   let handle_bool b = Option.map (fun (id, e) -> slocal id (ty TBool) e) b in
   let handle_cell id (cro1, cro2) =
@@ -367,6 +360,8 @@ let complex_body_to_stmt (body : complex_body) =
 
 let memop_body_to_stmt memop_body =
   match memop_body with
-  | TwoArg b -> simple_body_to_stmt b
-  | ThreeArg b | FourArg b -> complex_body_to_stmt b
+  | MBReturn e -> statement (SRet (Some e))
+  | MBIf (e1, e2, e3) ->
+    sifte e1 (statement (SRet (Some e2))) (statement (SRet (Some e3)))
+  | MBComplex b -> complex_body_to_stmt b
 ;;

--- a/src/lib/frontend/datastructures/Integer.ml
+++ b/src/lib/frontend/datastructures/Integer.ml
@@ -152,3 +152,9 @@ let compare x y =
 ;;
 
 let is_zero x = x.value = Z.zero
+
+let concat x y =
+  let sz = size x + size y in
+  let x', y' = set_size sz x, set_size sz y in
+  add (shift_left x' (size y)) y'
+;;

--- a/src/lib/frontend/modules/Arrays.ml
+++ b/src/lib/frontend/modules/Arrays.ml
@@ -199,7 +199,8 @@ let array_update_complex_error msg = array_error array_update_complex_name msg
 
 (* Type of Array.update_complex:
     Array<<'a>> -> int<<32>> ->
-   TMemop(3, 'a) -> int<<'a>> -> int<<'a>> ->
+   TMemop(3, 'a) ->
+   int<<'a>> -> int<<'a>> -> int<<'a>> ->
    int<<'a>>
 *)
 let array_update_complex_ty =
@@ -213,6 +214,7 @@ let array_update_complex_ty =
            ; ty @@ TInt (IVar (QVar (Id.fresh "sz")))
            ; ty @@ TMemop (3, a)
            ; ty @@ TInt a
+           ; ty @@ TInt a
            ; ty @@ TInt a ]
        ; ret_ty = ty @@ TInt a
        ; start_eff
@@ -224,10 +226,15 @@ let array_update_complex_ty =
 let array_update_complex_fun nst swid args =
   let open State in
   match args with
-  | [V { v = VGlobal stage }; V { v = VInt idx }; F memop; arg1; arg2] ->
+  | [V { v = VGlobal stage }; V { v = VInt idx }; F memop; arg1; arg2; default]
+    ->
     let update_f mem1 mem2 =
       let args =
-        [V (CoreSyntax.vinteger mem1); V (CoreSyntax.vinteger mem2); arg1; arg2]
+        [ V (CoreSyntax.vinteger mem1)
+        ; V (CoreSyntax.vinteger mem2)
+        ; arg1
+        ; arg2
+        ; default ]
       in
       let v = memop nst swid args in
       match v.v with

--- a/src/lib/frontend/modules/Arrays.ml
+++ b/src/lib/frontend/modules/Arrays.ml
@@ -39,13 +39,12 @@ let array_update_error msg = array_error array_update_name msg
 
 (* Type of Array.update:
     Array<<'a>> -> int<<32>> ->
-   TMemop(int<<'a>>, int<<'b>>) -> int<<'b>> ->
-   TMemop(int<<'a>>, int<<'a>>) -> int<<'a>> ->
+   TMemop(2, 'a) -> int<<'a>> ->
+   TMemop(2, 'a) -> int<<'a>> ->
    int<<'a>>
 *)
 let array_update_ty =
   let a = IVar (QVar (Id.fresh "a")) in
-  let b = IVar (QVar (Id.fresh "b")) in
   let arr_eff = FVar (QVar (Id.fresh "eff")) in
   let start_eff = FVar (QVar (Id.fresh "eff")) in
   ty
@@ -53,9 +52,9 @@ let array_update_ty =
        { arg_tys =
            [ ty_eff (TName (t_id, [a], true)) arr_eff
            ; ty @@ TInt (IVar (QVar (Id.fresh "sz")))
-           ; ty @@ TMemop (a, b)
-           ; ty @@ TInt b
-           ; ty @@ TMemop (a, a)
+           ; ty @@ TMemop (2, a)
+           ; ty @@ TInt a
+           ; ty @@ TMemop (2, a)
            ; ty @@ TInt a ]
        ; ret_ty = ty @@ TInt a
        ; start_eff
@@ -165,7 +164,6 @@ let array_setm_fun nst swid args =
 (* Types for the above four functions *)
 let array_get_ty, array_set_ty, array_getm_ty, array_setm_ty =
   let a = IVar (QVar (Id.fresh "a")) in
-  let b = IVar (QVar (Id.fresh "b")) in
   let arr_eff = FVar (QVar (Id.fresh "eff")) in
   let start_eff = FVar (QVar (Id.fresh "eff")) in
   let fty =
@@ -183,13 +181,61 @@ let array_get_ty, array_set_ty, array_getm_ty, array_setm_ty =
   , ty
     @@ TFun
          { fty with
-           arg_tys = fty.arg_tys @ [ty @@ TMemop (a, b); ty @@ TInt b]
+           arg_tys = fty.arg_tys @ [ty @@ TMemop (2, a); ty @@ TInt a]
          }
   , ty
     @@ TFun
          { fty with
-           arg_tys = fty.arg_tys @ [ty @@ TMemop (a, a); ty @@ TInt a]
+           arg_tys = fty.arg_tys @ [ty @@ TMemop (2, a); ty @@ TInt a]
          } )
+;;
+
+(* Array.update_complex *)
+
+let array_update_complex_name = "update_complex"
+let array_update_complex_id = Id.create array_update_complex_name
+let array_update_complex_cid = Cid.create_ids [array_id; array_update_complex_id]
+let array_update_complex_error msg = array_error array_update_complex_name msg
+
+(* Type of Array.update_complex:
+    Array<<'a>> -> int<<32>> ->
+   TMemop(3, 'a) -> int<<'a>> -> int<<'a>> ->
+   int<<'a>>
+*)
+let array_update_complex_ty =
+  let a = IVar (QVar (Id.fresh "a")) in
+  let arr_eff = FVar (QVar (Id.fresh "eff")) in
+  let start_eff = FVar (QVar (Id.fresh "eff")) in
+  ty
+  @@ TFun
+       { arg_tys =
+           [ ty_eff (TName (t_id, [a], true)) arr_eff
+           ; ty @@ TInt (IVar (QVar (Id.fresh "sz")))
+           ; ty @@ TMemop (3, a)
+           ; ty @@ TInt a
+           ; ty @@ TInt a ]
+       ; ret_ty = ty @@ TInt a
+       ; start_eff
+       ; end_eff = FSucc arr_eff
+       ; constraints = ref [CLeq (start_eff, arr_eff)]
+       }
+;;
+
+let array_update_complex_fun nst swid args =
+  let open State in
+  match args with
+  | [V { v = VGlobal stage }; V { v = VInt idx }; F memop; arg1; arg2] ->
+    let update_f mem1 mem2 =
+      let args =
+        [V (CoreSyntax.vinteger mem1); V (CoreSyntax.vinteger mem2); arg1; arg2]
+      in
+      let v = memop nst swid args in
+      match v.v with
+      | VTuple [VInt n1; VInt n2; v3] -> n1, n2, { v with v = v3 }
+      | _ -> failwith "array_update_complex: Internal error"
+    in
+    update_switch_complex swid stage (Integer.to_int idx) update_f nst
+  | _ -> array_update_complex_error "Incorrect number or type of arguments"
 ;;
 
 let constructors = [array_create_id, array_create_sig]
@@ -199,7 +245,11 @@ let defs : State.global_fun list =
   ; { cid = array_getm_cid; body = array_getm_fun; ty = array_getm_ty }
   ; { cid = array_set_cid; body = array_set_fun; ty = array_set_ty }
   ; { cid = array_setm_cid; body = array_setm_fun; ty = array_setm_ty }
-  ; { cid = array_update_cid; body = array_update_fun; ty = array_update_ty } ]
+  ; { cid = array_update_cid; body = array_update_fun; ty = array_update_ty }
+  ; { cid = array_update_complex_cid
+    ; body = array_update_complex_fun
+    ; ty = array_update_complex_ty
+    } ]
 ;;
 
 let signature =

--- a/src/lib/frontend/modules/Builtins.ml
+++ b/src/lib/frontend/modules/Builtins.ml
@@ -23,3 +23,7 @@ let ingr_port_ty = TInt (IConst 32) |> ty
 
 (* Used in constraints *)
 let start_id = Id.create "start"
+
+(* Used in memops *)
+let cell1_id = SyntaxUtils.cell1_id
+let cell2_id = SyntaxUtils.cell2_id

--- a/src/lib/frontend/modules/Builtins.ml
+++ b/src/lib/frontend/modules/Builtins.ml
@@ -6,14 +6,20 @@ let self_ty = ty (TInt (IConst 32))
 let recirc_id = Id.create "recirculation_port"
 let recirc_ty = ty (TInt (IConst 32))
 let builtin_vars = [self_id, self_ty; recirc_id, recirc_ty]
-let builtin_type_ids = [Arrays.t_id; Counters.t_id]
+let builtin_type_ids = [Arrays.t_id; Counters.t_id; PairArrays.t_id]
 
 (* Building modules *)
 let builtin_modules =
-  [Arrays.signature; Counters.signature; Events.signature; System.signature]
+  [ Arrays.signature
+  ; Counters.signature
+  ; Events.signature
+  ; System.signature
+  ; PairArrays.signature ]
 ;;
 
-let builtin_defs = Arrays.defs @ Counters.defs @ Events.defs @ System.defs
+let builtin_defs =
+  Arrays.defs @ Counters.defs @ Events.defs @ System.defs @ PairArrays.defs
+;;
 
 (* Not a global var *)
 let this_id = Id.create "this"

--- a/src/lib/frontend/modules/PairArrays.ml
+++ b/src/lib/frontend/modules/PairArrays.ml
@@ -1,0 +1,97 @@
+(* Interpretation of stateful pairarrays. *)
+open Batteries
+open Syntax
+open InterpState
+
+(* Generic PairArray defs *)
+let pairarray_name = "PairArray"
+let pairarray_id = Id.create pairarray_name
+
+let pairarray_error fun_name msg =
+  error (pairarray_name ^ ": " ^ fun_name ^ ": " ^ msg)
+;;
+
+let module_id = pairarray_id
+let t_id = Cid.create_ids [pairarray_id; Id.create "t"]
+let sizes_labels = [Id.create "dummy_sz"], []
+
+(* Constructor *)
+let pairarray_create_id = Cid.create_ids [pairarray_id; Id.create "create"]
+
+let pairarray_create_sig =
+  let pairarray_size = IVar (QVar (Id.fresh "a")) in
+  let pairarray_eff = FVar (QVar (Id.fresh "eff")) in
+  let start_eff = FVar (QVar (Id.fresh "eff")) in
+  { arg_tys = [ty @@ TInt pairarray_size]
+  ; ret_ty = ty_eff (TName (t_id, [pairarray_size], true)) pairarray_eff
+  ; start_eff
+  ; end_eff = start_eff
+  ; constraints = ref []
+  }
+;;
+
+(* PairArray.update *)
+
+let pairarray_update_name = "update"
+let pairarray_update_id = Id.create pairarray_update_name
+let pairarray_update_cid = Cid.create_ids [pairarray_id; pairarray_update_id]
+let pairarray_update_error msg = pairarray_error pairarray_update_name msg
+
+let pairarray_update_ty =
+  let a = IVar (QVar (Id.fresh "a")) in
+  let arr_eff = FVar (QVar (Id.fresh "eff")) in
+  let start_eff = FVar (QVar (Id.fresh "eff")) in
+  ty
+  @@ TFun
+       { arg_tys =
+           [ ty_eff (TName (t_id, [a], true)) arr_eff
+           ; ty @@ TInt (IVar (QVar (Id.fresh "sz")))
+           ; ty @@ TMemop (4, a)
+           ; ty @@ TInt a
+           ; ty @@ TInt a
+           ; ty @@ TInt a ]
+       ; ret_ty = ty @@ TInt a
+       ; start_eff
+       ; end_eff = FSucc arr_eff
+       ; constraints = ref [CLeq (start_eff, arr_eff)]
+       }
+;;
+
+let pairarray_update_fun nst swid args =
+  let open State in
+  match args with
+  | [V { v = VGlobal stage }; V { v = VInt idx }; F memop; arg1; arg2; default]
+    ->
+    let update_f mem1 mem2 =
+      let args =
+        [ V (CoreSyntax.vinteger mem1)
+        ; V (CoreSyntax.vinteger mem2)
+        ; arg1
+        ; arg2
+        ; default ]
+      in
+      let v = memop nst swid args in
+      match v.v with
+      | VTuple [VInt n1; VInt n2; v3] -> n1, n2, { v with v = v3 }
+      | _ -> failwith "array_update: Internal error"
+    in
+    update_switch_complex swid stage (Integer.to_int idx) update_f nst
+  | _ -> pairarray_update_error "Incorrect number or type of arguments"
+;;
+
+let constructors = [pairarray_create_id, pairarray_create_sig]
+
+let defs : State.global_fun list =
+  [ { cid = pairarray_update_cid
+    ; body = pairarray_update_fun
+    ; ty = pairarray_update_ty
+    } ]
+;;
+
+let signature =
+  let sz = IVar (QVar (Id.fresh "sz")) in
+  ( module_id
+  , [Cid.last_id t_id, [sz], TName (t_id, [sz], true) |> ty]
+  , defs
+  , constructors )
+;;

--- a/src/lib/frontend/modules/PairArrays.mli
+++ b/src/lib/frontend/modules/PairArrays.mli
@@ -1,0 +1,12 @@
+open InterpState
+open Syntax
+
+val module_id : Id.t
+val t_id : Cid.t
+val sizes_labels : Id.t list * Syntax.params
+val constructors : (Cid.t * Syntax.func_ty) list
+val defs : State.global_fun list
+
+val signature:
+  Id.t * (Id.t * sizes * ty) list * State.global_fun list * (Cid.t * func_ty) list
+[@@ocamlformat "disable"]

--- a/src/lib/frontend/transformations/EStmtElimination.ml
+++ b/src/lib/frontend/transformations/EStmtElimination.ml
@@ -96,7 +96,7 @@ let eliminator =
     method! visit_statement _ s = inline_stmt s
 
     (* Don't replace inside memops, it confuses the typer and is semantically a no-op anyway *)
-    method! visit_DMemop _ id body = DMemop (id, body)
+    method! visit_DMemop _ id params body = DMemop (id, params, body)
   end
 ;;
 

--- a/src/lib/frontend/transformations/ModuleElimination.ml
+++ b/src/lib/frontend/transformations/ModuleElimination.ml
@@ -61,7 +61,7 @@ let add_definitions prefix env ds =
     | DExtern (id, _)
     | DSymbolic (id, _)
     | DFun (id, _, _, _)
-    | DMemop (id, _)
+    | DMemop (id, _, _)
     | DEvent (id, _, _, _)
     | DHandler (id, _)
     | DConstr (id, _, _, _)
@@ -113,9 +113,9 @@ let rec replace_module env m_id ds =
           | DFun (id, x, y, z) ->
             ( { env with vars = add_entry env.vars id }
             , DFun (prefix id, x, y, z) |> wrap d )
-          | DMemop (id, x) ->
+          | DMemop (id, x, y) ->
             ( { env with vars = add_entry env.vars id }
-            , DMemop (prefix id, x) |> wrap d )
+            , DMemop (prefix id, x, y) |> wrap d )
           | DEvent (id, x, y, z) ->
             ( { env with vars = add_entry env.vars id }
             , DEvent (prefix id, x, y, z) |> wrap d )

--- a/src/lib/frontend/transformations/Renaming.ml
+++ b/src/lib/frontend/transformations/Renaming.ml
@@ -105,7 +105,11 @@ let rename prog =
             (start_id :: ingr_port_id :: this_id :: List.map fst builtin_vars)
         in
         let builtin_cids =
-          List.map fst (Arrays.constructors @ Counters.constructors)
+          List.map
+            fst
+            (Arrays.constructors
+            @ Counters.constructors
+            @ PairArrays.constructors)
           @ List.map
               (fun (gf : InterpState.State.global_fun) -> gf.cid)
               builtin_defs
@@ -120,7 +124,7 @@ let rename prog =
           List.fold_left
             (fun env cid -> CidMap.add cid cid env)
             CidMap.empty
-            [Arrays.t_id; Counters.t_id]
+            [Arrays.t_id; Counters.t_id; PairArrays.t_id]
         in
         { empty_env with var_map; ty_map }
 
@@ -231,13 +235,21 @@ let rename prog =
               (fun (id, ty) -> self#freshen_var id, self#visit_ty dummy ty)
               params
           in
-          let added_cell_ids =
-            List.fold_left
-              (fun acc id -> CidMap.add (Id id) (Id id) acc)
-              env.var_map
-              [Builtins.cell1_id; Builtins.cell2_id]
+          let var_map =
+            match body with
+            | MBComplex body ->
+              let bound_ids =
+                [body.b1; body.b2]
+                |> List.filter_map (fun x -> x)
+                |> List.map fst
+              in
+              List.fold_left
+                (fun acc id -> CidMap.add (Id id) (Id id) acc)
+                env.var_map
+                ([Builtins.cell1_id; Builtins.cell2_id] @ bound_ids)
+            | _ -> env.var_map
           in
-          env <- { env with var_map = added_cell_ids };
+          env <- { env with var_map };
           let replaced_body = self#visit_memop_body dummy body in
           env <- old_env;
           let new_x = self#freshen_var x in

--- a/src/lib/frontend/typing/Typer.ml
+++ b/src/lib/frontend/typing/Typer.ml
@@ -958,7 +958,9 @@ let rec infer_declaration (env : env) (effect_count : effect) (d : decl)
         | { raw_ty = TInt sz } -> sz
         | _ -> failwith "Memops.ml should make this impossible"
       in
-      let tmem = TMemop (List.length params, sz) in
+      let tmem =
+        TMemop (List.length params, sz) |> generalizer#visit_raw_ty ()
+      in
       let env = define_const id (ty tmem) env in
       env, effect_count, DMemop (id, params, inf_body)
     | DUserTy (id, sizes, ty) ->

--- a/src/lib/frontend/typing/Typer.ml
+++ b/src/lib/frontend/typing/Typer.ml
@@ -722,6 +722,7 @@ let infer_body env (params, s) =
 ;;
 
 let infer_memop span env (params, s) =
+  let open TyperMemops in
   (* First, make sure we have the right number/type of arguments *)
   let arg1size = fresh_size () in
   let arg2size = fresh_size () in

--- a/src/lib/frontend/typing/Typer.ml
+++ b/src/lib/frontend/typing/Typer.ml
@@ -722,7 +722,6 @@ let infer_body env (params, s) =
 ;;
 
 let infer_memop span env (params, s) =
-  let open TyperMemops in
   (* First, make sure we have the right number/type of arguments *)
   let arg1size = fresh_size () in
   let arg2size = fresh_size () in
@@ -950,7 +949,7 @@ let rec infer_declaration (env : env) (effect_count : effect) (d : decl)
       ^ " is "
       ^ raw_ty_to_string (TFun fty); *)
       env, effect_count, DFun (id, ret_ty, constr_specs, inf_body)
-    | DMemop (id, body) ->
+    | DMemop (id, params, memop_body) ->
       enter_level ();
       let inf_size1, inf_size2, inf_memop = infer_memop d.dspan env body in
       leave_level ();

--- a/src/lib/frontend/typing/Typer.ml
+++ b/src/lib/frontend/typing/Typer.ml
@@ -734,10 +734,10 @@ let infer_memop env params mbody =
   let check_int env e = check_e env expected_tint e in
   let env = add_locals env params in
   match mbody with
-  | TwoArg (SBReturn e) -> TwoArg (SBReturn (check_int env e))
-  | TwoArg (SBIf (e1, e2, e3)) ->
-    TwoArg (SBIf (check_bool env e1, check_int env e2, check_int env e3))
-  | ThreeArg body | FourArg body ->
+  | MBReturn e -> MBReturn (check_int env e)
+  | MBIf (e1, e2, e3) ->
+    MBIf (check_bool env e1, check_int env e2, check_int env e3)
+  | MBComplex body ->
     let check_b env (id, e) = id, check_bool env e in
     let b1 = Option.map (check_b env) body.b1 in
     let b2 = Option.map (check_b env) body.b2 in
@@ -759,9 +759,7 @@ let infer_memop env params mbody =
         [Builtins.cell1_id, expected_tint; Builtins.cell2_id, expected_tint]
     in
     let ret = Option.map (infer_cr env) body.ret in
-    (match mbody with
-    | ThreeArg _ -> ThreeArg { b1; b2; cell1; cell2; ret }
-    | _ -> FourArg { b1; b2; cell1; cell2; ret })
+    MBComplex { b1; b2; cell1; cell2; ret }
 ;;
 
 (* Check that the event id has already been defined, and that it has the

--- a/src/lib/frontend/typing/TyperMemops.ml
+++ b/src/lib/frontend/typing/TyperMemops.ml
@@ -1,0 +1,294 @@
+open Syntax
+open SyntaxUtils
+open Collections
+open Batteries
+open TyperUtil
+
+(** Inference and well-formedness for memops *)
+
+(* Validate that the expression only uses one of each kind of variable (memory/local),
+   doesn't use any other variables, and only uses allowed operations *)
+let check_e memvars localvars allowed_op exp =
+  let mem cid lst =
+    match cid with
+    | Compound _ -> false
+    | Id id ->
+      (match List.find_opt (Id.equals id) lst with
+      | None -> false
+      | Some _ -> true)
+  in
+  let rec aux (seen_mem, seen_local) e =
+    match e.e with
+    | EVal _ | EInt _ -> seen_mem, seen_local
+    | EVar cid when mem cid memvars ->
+      if not seen_mem
+      then true, seen_local
+      else
+        error_sp
+          exp.espan
+          "Second use of a memory parameter in a single memop expression"
+    | EVar cid when mem cid localvars ->
+      if not seen_local
+      then seen_mem, true
+      else
+        error_sp
+          exp.espan
+          "Second use of a local parameter in a single memop expression"
+    | EVar _ -> seen_mem, seen_local
+    | EOp (op, [e1; e2]) ->
+      if allowed_op op
+      then (
+        let seen_vars = aux (seen_mem, seen_local) e1 in
+        aux seen_vars e2)
+      else
+        error_sp
+          e.espan
+          ("Disallowed operation in memop expression" ^ Printing.exp_to_string e)
+    | _ ->
+      error_sp
+        e.espan
+        ("Disallowed expression in memop expression: "
+        ^ Printing.exp_to_string e)
+  in
+  ignore @@ aux (false, false) exp
+;;
+
+let allowed_bool_op = function
+  | Eq | Neq | Less | More -> true
+  | _ -> false
+;;
+
+let allowed_int_op = function
+  | Plus | Sub | BitAnd | BitOr -> true
+  | _ -> false
+;;
+
+let check_bool_exp memvars localvars e =
+  (* We might have things like `mem1 + local1 <= 3` *)
+  let allowed_op b = allowed_bool_op b || allowed_int_op b in
+  check_e memvars localvars allowed_op e
+;;
+
+let check_int_exp memvars localvars e =
+  check_e memvars localvars allowed_int_op e
+;;
+
+(* Conditional expressions in complex memops have different requirements: they
+   only allow combinations of the two booleans defined at the beginning of the
+   expression, plus constant/symbolic variables *)
+let check_conditional allowed_var e =
+  let rec aux e =
+    match e.e with
+    | EVal _ -> ()
+    | EVar cid ->
+      if not (allowed_var cid)
+      then
+        error_sp e.espan "Disallowed variable in memop conditional expression"
+    | EOp (op, [e1; e2]) ->
+      if not (allowed_bool_op op)
+      then
+        error_sp
+          e.espan
+          ("Disallowed operation in memop expression" ^ Printing.exp_to_string e);
+      aux e1;
+      aux e2
+    | _ ->
+      error_sp
+        e.espan
+        ("Disallowed expression in memop expression: "
+        ^ Printing.exp_to_string e)
+  in
+  aux e
+;;
+
+type simple_body =
+  | Return of exp
+  | If of exp * exp * exp
+
+(* Boolean condition * return value *)
+type conditional_return = exp * exp
+
+type complex_body =
+  { b1 : exp option
+  ; b2 : exp option
+  ; cell1 : conditional_return option * conditional_return option
+  ; cell2 : conditional_return option * conditional_return option
+  ; ret : conditional_return option
+  }
+
+type memop =
+  | TwoArg of simple_body
+  | ThreeArg of complex_body
+  | FourArg of complex_body
+
+let extract_simple_body mem1 local1 body =
+  let check_int = check_int_exp [mem1] [local1] in
+  let check_bool = check_int_exp [mem1] [local1] in
+  match flatten_stmt body with
+  | [{ s = SRet (Some e) }] ->
+    check_int e;
+    Return e
+  | [{ s = SIf (e, s1, s2) }] ->
+    check_bool e;
+    (match flatten_stmt s1, flatten_stmt s2 with
+    | [{ s = SRet (Some e1) }], [{ s = SRet (Some e2) }] ->
+      check_int e1;
+      check_int e2;
+      If (e, e1, e2)
+    | _ ->
+      error_sp body.sspan "Invalid if statement in a memop with two arguments")
+  | _ -> error_sp body.sspan "Invalid form for a memop with two arguments"
+;;
+
+(* Simplified representation of the statements in the body, as an intermediate form
+   while putting together a complex_body *)
+type complex_stmt =
+  | BoolDef of id * exp
+  | CellAssign of id * conditional_return option * conditional_return option
+  | LocalRet of conditional_return
+
+let classify_stmts (body : statement) : (complex_stmt * sp) list =
+  let classify s =
+    let ret =
+      match s.s with
+      | SLocal (id, { raw_ty = TBool }, e) -> BoolDef (id, e)
+      | SIf (test1, s1, s2) ->
+        begin
+          match flatten_stmt s1, flatten_stmt s2 with
+          | [{ s = SRet (Some ret) }], [] -> LocalRet (test1, ret)
+          | [{ s = SAssign (id1, ret1) }], [] ->
+            CellAssign (id1, Some (test1, ret1), None)
+          | [{ s = SAssign (id1, ret1) }], [{ s = SIf (test2, s1', s2') }] ->
+            begin
+              match flatten_stmt s1', flatten_stmt s2' with
+              | [{ s = SAssign (id2, ret2) }], [] ->
+                if not (Id.equal id1 id2)
+                then
+                  error_sp s1.sspan
+                  @@ "If a complex memop has an if/else, both parts must \
+                      assign to the same cell variable, not "
+                  ^ Id.name id1
+                  ^ " and "
+                  ^ Id.name id2;
+                CellAssign (id1, Some (test1, ret1), Some (test2, ret2))
+              | _ -> error_sp s.sspan "Invalid if statement in complex memop"
+            end
+          | _ -> error_sp s.sspan "Invalid if statement in complex memop"
+        end
+      | _ -> error_sp s.sspan "Invalid statement type in complex memop"
+    in
+    ret, s.sspan
+  in
+  body |> flatten_stmt |> List.map classify
+;;
+
+let cell1_id = Id.create "cell1"
+let cell2_id = Id.create "cell2"
+
+(* Ensure that each cell id appears at most once, and no invalid ids are used *)
+let check_cell_ids stmts =
+  let counts = (* Seen cell1, Seen cell2 *) ref (false, false) in
+  List.iter
+    (function
+      | BoolDef _, _ | LocalRet _, _ -> ()
+      | CellAssign (id, _, _), sp when Id.equal id cell1_id ->
+        if fst !counts
+        then
+          error_sp sp
+          @@ Id.name cell1_id
+          ^ " is assigned to in multiple parts of this memop";
+        counts := true, snd !counts
+      | CellAssign (id, _, _), sp when Id.equal id cell2_id ->
+        if snd !counts
+        then
+          error_sp sp
+          @@ Id.name cell2_id
+          ^ " is assigned to in multiple parts of this memop";
+        counts := fst !counts, true
+      | CellAssign (id, _, _), sp ->
+        error_sp sp
+        @@ Id.name id
+        ^ " is not a valid cell identifier (should be cell1 or cell2)")
+    stmts
+;;
+
+let extract_complex_body mems locals body =
+  let check_int = check_int_exp mems locals in
+  let check_bool = check_int_exp mems locals in
+  let body = classify_stmts body in
+  check_cell_ids body;
+  let extract_booldef b_ids body =
+    match body with
+    | (BoolDef (id, e), _) :: tl ->
+      check_bool e;
+      Some e, id :: b_ids, tl
+    | _ -> None, b_ids, body
+  in
+  let b1, b_ids, body = extract_booldef [] body in
+  let b2, b_ids, body = extract_booldef b_ids body in
+  let check_cond e =
+    check_conditional
+      (function
+        | Compound _ -> false
+        | Id id -> List.mem id b_ids)
+      e
+  in
+  let cell1, cell2, body =
+    match body with
+    | (CellAssign (id1, cr1_1, cr1_2), _)
+      :: (CellAssign (_, cr2_1, cr2_2), _) :: tl ->
+      if Id.name id1 = Id.name cell1_id
+      then (cr1_1, cr1_2), (cr2_1, cr2_2), tl
+      else (cr2_1, cr2_2), (cr1_1, cr1_2), tl
+    | (CellAssign (id1, cr1_1, cr1_2), _) :: tl ->
+      if Id.name id1 = Id.name cell1_id
+      then (cr1_1, cr1_2), (None, None), tl
+      else (None, None), (cr1_1, cr1_2), tl
+    | _ -> (None, None), (None, None), body
+  in
+  let ret =
+    match body with
+    | [] -> None
+    | [(LocalRet cr, _)] -> Some cr
+    | (_, sp) :: _ ->
+      error_sp sp
+      @@ "Unexpected statement in a memop. Are you sure your statements are in \
+          order?"
+  in
+  { b1; b2; cell1; cell2; ret }
+;;
+
+let ensure_same_size span params =
+  if List.is_empty params
+  then Console.error_position span "A memop cannot have 0 arguments!";
+  let sizes =
+    List.map
+      (fun (_, ty) ->
+        match ty.raw_ty with
+        | TInt sz -> sz
+        | _ ->
+          Console.error_position
+            ty.tspan
+            "All arguments to a memop must be integers")
+      params
+  in
+  if not (List.for_all (equiv_size (List.hd sizes)) sizes)
+  then
+    Console.error_position
+      span
+      " All arguments to a memop must have the same size"
+;;
+
+(* Verify that a memop is well-formed, and turn it from a statement into a memop.
+   There are three kinds of memop (see Language Features on the wiki for details),
+   which can be distinguished by the number of arguments they take. *)
+let extract_memop span (params : params) (body : statement) : memop =
+  ensure_same_size span params;
+  match params with
+  | [(mem1, _); (local1, _)] -> TwoArg (extract_simple_body mem1 local1 body)
+  | [(mem1, _); (local1, _); (local2, _)] ->
+    ThreeArg (extract_complex_body [mem1] [local1; local2] body)
+  | [(mem1, _); (mem2, _); (local1, _); (local2, _)] ->
+    FourArg (extract_complex_body [mem1; mem2] [local1; local2] body)
+  | _ -> failwith ""
+;;

--- a/src/lib/frontend/typing/TyperUnify.ml
+++ b/src/lib/frontend/typing/TyperUnify.ml
@@ -219,9 +219,9 @@ and try_unify_rty span rty1 rty2 =
       ty
   | TBool, TBool | TVoid, TVoid | TGroup, TGroup | TEvent, TEvent -> ()
   | TInt size1, TInt size2 -> try_unify_size span size1 size2
-  | TMemop (size1a, size1b), TMemop (size2a, size2b) ->
-    try_unify_size span size1a size2a;
-    try_unify_size span size1b size2b
+  | TMemop (n1, size1), TMemop (n2, size2) ->
+    if n1 <> n2 then raise CannotUnify;
+    try_unify_size span size1 size2
   | TName (cid1, sizes1, b1), TName (cid2, sizes2, b2) ->
     if b1 <> b2 || not (Cid.equal cid1 cid2) then raise CannotUnify;
     List.iter2 (try_unify_size span) sizes1 sizes2

--- a/src/lib/frontend/typing/TyperUnify.ml
+++ b/src/lib/frontend/typing/TyperUnify.ml
@@ -220,7 +220,13 @@ and try_unify_rty span rty1 rty2 =
   | TBool, TBool | TVoid, TVoid | TGroup, TGroup | TEvent, TEvent -> ()
   | TInt size1, TInt size2 -> try_unify_size span size1 size2
   | TMemop (n1, size1), TMemop (n2, size2) ->
-    if n1 <> n2 then raise CannotUnify;
+    if n1 <> n2
+    then
+      error_sp span
+      @@ Printf.sprintf
+           "Unification error: memops has wrong number of arumgnets (%d vs %d)"
+           n1
+           n2;
     try_unify_size span size1 size2
   | TName (cid1, sizes1, b1), TName (cid2, sizes2, b2) ->
     if b1 <> b2 || not (Cid.equal cid1 cid2) then raise CannotUnify;

--- a/src/lib/frontend/typing/TyperUtil.ml
+++ b/src/lib/frontend/typing/TyperUtil.ml
@@ -283,68 +283,6 @@ let textract (env, e) =
   | Some ty -> env, e, ty
 ;;
 
-(** Inference and well-formedness for memops. They have a lot of restrictions
-    on them: They must have exactly two arguments, an int<<'a>> and a 'b, plus
-    their bodies follow a restricted grammar *)
-
-(* An expression in a memop may use an unlimited number of binops, but
-   only some are allowed. Furthermore, each parameter can appear only once in the
-   expression; all other arguments must be constants. *)
-let check_e cid1 cid2 allowed (seen1, seen2) exp =
-  let rec aux (seen1, seen2) e =
-    match e.e with
-    | EVal _ | EInt _ -> seen1, seen2
-    | EVar cid when Cid.equals cid cid1 ->
-      if not seen1
-      then true, seen2
-      else
-        error_sp
-          exp.espan
-          ("Parameter "
-          ^ Cid.to_string cid
-          ^ " appears more than once in memop expression")
-    | EVar cid when Cid.equals cid cid2 ->
-      if not seen2
-      then seen1, true
-      else
-        error_sp
-          exp.espan
-          ("Parameter "
-          ^ Cid.to_string cid
-          ^ " appears more than once in memop expression")
-    | EVar _ -> seen1, seen2
-    | EOp (op, [e1; e2]) ->
-      if allowed op
-      then (
-        let seen_vars = aux (seen1, seen2) e1 in
-        aux seen_vars e2)
-      else
-        error_sp
-          e.espan
-          ("Disallowed operation in memop expression" ^ Printing.exp_to_string e)
-    | _ ->
-      error_sp
-        e.espan
-        ("Disallowed expression in memop expression: "
-        ^ Printing.exp_to_string e)
-  in
-  aux (seen1, seen2) exp
-;;
-
-(* Similar to check_return, except the test of the body also conditionals *)
-let check_test id1 id2 exp =
-  let check_e = check_e (Id id1) (Id id2) in
-  let allowed = function
-    | Plus | Sub -> true
-    | _ -> false
-  in
-  match exp.e with
-  | EOp ((Eq | Neq | Less | More), [e1; e2]) ->
-    let seen_vars1 = check_e allowed (false, false) e1 in
-    ignore @@ check_e allowed seen_vars1 e2
-  | _ -> ignore @@ check_e allowed (false, false) exp
-;;
-
 (* Construct the type for an event creation function given its constraints
    and parameters *)
 let mk_event_ty constrs params =
@@ -556,4 +494,13 @@ let rec modul_to_string ?(show_defs = true) m =
          str ^ ", " ^ acc)
        m.submodules
        "")
+;;
+
+(* Note: causes an unbound variable error if the variable is unbound *)
+let is_const env span id =
+  match IdMap.find_opt id env.locals with
+  | Some _ -> false
+  | None ->
+    (match lookup_var span env (Id id) with
+    | _ -> true)
 ;;

--- a/src/lib/frontend/typing/TyperUtil.ml
+++ b/src/lib/frontend/typing/TyperUtil.ml
@@ -259,6 +259,13 @@ let lookup_module span env cid =
     ^ Printing.cid_to_string cid
 ;;
 
+let add_locals env bindings =
+  let locals =
+    List.fold_left (fun acc (id, ty) -> IdMap.add id ty acc) env.locals bindings
+  in
+  { env with locals }
+;;
+
 (* Drops the last n constraints in the second environment and returns
    the rest. For use after if/match statments, where the result after
    each side constains all the constraints from the original env plus

--- a/src/lib/midend/CorePrinting.ml
+++ b/src/lib/midend/CorePrinting.ml
@@ -98,6 +98,7 @@ let rec v_to_string v =
   | VEvent event -> event_to_string event
   | VGlobal i -> "global_" ^ string_of_int i
   | VGroup vs -> Printf.sprintf "{%s}" (comma_sep location_to_string vs)
+  | VTuple vs -> Printf.sprintf "(%s)" (comma_sep v_to_string vs)
 
 and value_to_string v = v_to_string v.v
 

--- a/src/lib/midend/CorePrinting.ml
+++ b/src/lib/midend/CorePrinting.ml
@@ -33,11 +33,7 @@ let rec raw_ty_to_string t =
     ^ if cfg.verbose_types then "{" ^ string_of_bool b ^ "}" else ""
   | TEvent -> "event"
   | TFun func -> func_to_string func
-  | TMemop (size1, size2) ->
-    Printf.sprintf
-      "memop[int<<%s>>, %s]"
-      (size_to_string size1)
-      (size_to_string size2)
+  | TMemop (n, size) -> Printf.sprintf "memop%d<<%s>>" n (size_to_string size)
   | TGroup -> "group"
 
 and func_to_string func =
@@ -212,6 +208,38 @@ let event_sort_to_string sort =
   | EBackground -> "event"
 ;;
 
+let memop_to_string body =
+  match body with
+  | MBReturn e -> "return " ^ exp_to_string e ^ ";\n"
+  | MBIf (e1, e2, e3) ->
+    Printf.sprintf
+      "if %s then %s else %s"
+      (exp_to_string e1)
+      (exp_to_string e2)
+      (exp_to_string e3)
+  | MBComplex body ->
+    let print_b b =
+      match b with
+      | None -> "None"
+      | Some (id, e) -> Id.name id ^ "," ^ exp_to_string e |> wrap "(" ")"
+    in
+    let print_cr cro =
+      match cro with
+      | None -> "None"
+      | Some (e1, e2) ->
+        exp_to_string e1 ^ " -> " ^ exp_to_string e2 |> wrap "(" ")"
+    in
+    Printf.sprintf
+      "{\nb1=%s;\nb2=%s\ncell1=%s, %s\ncell2=%s, %s\nret=%s\n}"
+      (print_b body.b1)
+      (print_b body.b2)
+      (print_cr @@ fst body.cell1)
+      (print_cr @@ snd body.cell1)
+      (print_cr @@ fst body.cell2)
+      (print_cr @@ snd body.cell2)
+      (print_cr @@ body.ret)
+;;
+
 let d_to_string d =
   match d with
   | DGlobal (id, ty, exp) ->
@@ -232,12 +260,12 @@ let d_to_string d =
       (event_sort_to_string sort)
       (id_to_string id)
       (params_to_string params)
-  | DMemop (id, (params, s)) ->
+  | DMemop (id, params, mbody) ->
     Printf.sprintf
       "memop %s(%s)\n {%s}"
       (id_to_string id)
       (params_to_string params)
-      (stmt_to_string s)
+      (memop_to_string mbody)
   | DExtern (id, ty) ->
     Printf.sprintf "extern %s %s;" (id_to_string id) (ty_to_string ty)
 ;;

--- a/src/lib/midend/CoreSyntax.ml
+++ b/src/lib/midend/CoreSyntax.ml
@@ -77,6 +77,7 @@ and v =
   | VInt of zint
   | VEvent of event
   | VGlobal of int (* Stage number *)
+  | VTuple of v list (* Only used in the interpreter during complex memops *)
   | VGroup of location list
 
 and event =
@@ -193,6 +194,8 @@ let infer_vty v =
   | VEvent _ -> TEvent
   | VGroup _ -> TGroup
   | VGlobal _ -> failwith "Cannot infer type of global value"
+  | VTuple _ ->
+    failwith "Cannot infer type of tuple value (only used in complex memops)"
 ;;
 
 (* Values *)

--- a/src/lib/midend/interpreter/Interp.ml
+++ b/src/lib/midend/interpreter/Interp.ml
@@ -13,7 +13,7 @@ let initial_state (pp : Preprocess.t) (spec : InterpSpec.t) =
   (* Add builtins *)
   List.iter
     (fun f -> State.add_global_function f nst)
-    (System.defs @ Events.defs @ Counters.defs @ Arrays.defs);
+    (System.defs @ Events.defs @ Counters.defs @ Arrays.defs @ PairArrays.defs);
   (* Add externs *)
   List.iteri
     (fun i exs -> Env.iter (fun cid v -> State.add_global i cid (V v) nst) exs)

--- a/src/lib/midend/interpreter/InterpCore.ml
+++ b/src/lib/midend/interpreter/InterpCore.ml
@@ -59,9 +59,7 @@ let interp_op op vs =
     else vinteger (Integer.sub (raw_integer v1) (raw_integer v2))
   | Conc, [v1; v2] ->
     let v1, v2 = raw_integer v1, raw_integer v2 in
-    let sz = Integer.size v1 + Integer.size v2 in
-    let v1', v2' = Integer.set_size sz v1, Integer.set_size sz v2 in
-    vinteger (Integer.add (Integer.shift_left v1' (Integer.size v2)) v2')
+    vinteger (Integer.concat v1 v2)
   | BitAnd, [v1; v2] ->
     vinteger (Integer.bitand (raw_integer v1) (raw_integer v2))
   | BitOr, [v1; v2] ->

--- a/src/lib/midend/interpreter/InterpState.ml
+++ b/src/lib/midend/interpreter/InterpState.ml
@@ -61,6 +61,8 @@ module State = struct
 
   and code = network_state -> int (* switch *) -> ival list -> value
 
+  and memop
+
   and handler =
     network_state -> int (* switch *) -> int (* port *) -> event -> unit
 
@@ -206,6 +208,10 @@ module State = struct
 
   let update_switch swid stage idx getop setop nst =
     Pipeline.update ~stage ~idx ~getop ~setop nst.switches.(swid).pipeline
+  ;;
+
+  let update_switch_complex swid stage idx memop nst =
+    Pipeline.update_complex ~stage ~idx ~memop nst.switches.(swid).pipeline
   ;;
 
   (* Maps switch * port -> switch * port according to the topology *)

--- a/src/lib/midend/interpreter/Pipeline.ml
+++ b/src/lib/midend/interpreter/Pipeline.ml
@@ -5,7 +5,7 @@ open CoreSyntax
 type stage = zint array * bool
 
 let split_integer n =
-  let sz = Integer.size n in
+  let sz = Integer.size n / 2 in
   let upper = Integer.shift_right n sz |> Integer.set_size sz in
   let lower = Integer.set_size sz n in
   upper, lower
@@ -127,7 +127,9 @@ let update_complex
       let new_upper, new_lower, ret = memop upper lower in
       Integer.concat new_upper new_lower, ret
     | false ->
-      let new_val, _, ret = memop orig_val (Integer.of_int 0) in
+      let new_val, _, ret =
+        memop orig_val (Integer.create ~value:0 ~size:(Integer.size orig_val))
+      in
       new_val, ret
   in
   arr.(idx) <- new_val;

--- a/src/lib/midend/interpreter/Pipeline.ml
+++ b/src/lib/midend/interpreter/Pipeline.ml
@@ -1,5 +1,5 @@
 open Batteries
-open Syntax
+open CoreSyntax
 
 type t =
   { arrs : zint array array

--- a/src/lib/midend/interpreter/Pipeline.ml
+++ b/src/lib/midend/interpreter/Pipeline.ml
@@ -1,36 +1,46 @@
 open Batteries
 open CoreSyntax
 
+(* Bool is true if this is a paired array *)
+type stage = zint array * bool
+
+let split_integer n =
+  let sz = Integer.size n in
+  let upper = Integer.shift_right n sz |> Integer.set_size sz in
+  let lower = Integer.set_size sz n in
+  upper, lower
+;;
+
 type t =
-  { arrs : zint array array
+  { arrs : stage array
   ; current_stage : int ref
   }
 
 let empty () =
-  { arrs = Array.make 0 (Array.make 0 (Integer.of_int 0))
+  { arrs = Array.make 0 (Array.make 0 (Integer.of_int 0), false)
   ; current_stage = ref 0
   }
 ;;
 
-let append_stage ~(width : int) ~(length : int) t =
-  let new_arr = Array.make length (Integer.create 0 width) in
-  { t with arrs = Array.append t.arrs (Array.make 1 new_arr) }
+let append_stage ~(width : int) ~(length : int) ~(pair : bool) t =
+  let full_width = if pair then width * 2 else width in
+  let new_arr = Array.make length (Integer.create 0 full_width) in
+  { t with arrs = Array.append t.arrs @@ Array.make 1 (new_arr, pair) }
 ;;
 
-let of_globals (gs : (int * int) list) =
-  let arrs =
+let of_globals (gs : (int * int * bool) list) =
+  List.fold_left
+    (fun acc (width, length, pair) -> append_stage ~width ~length ~pair acc)
+    (empty ())
     gs
-    |> List.map (fun (width, length) ->
-           Array.make length (Integer.create 0 width))
-    |> Array.of_list
-  in
-  { arrs; current_stage = ref 0 }
 ;;
 
 let reset_stage t = t.current_stage := 0
 
 let copy t =
-  { arrs = Array.map Array.copy t.arrs; current_stage = ref !(t.current_stage) }
+  { arrs = Array.map (fun (arr, o) -> Array.copy arr, o) t.arrs
+  ; current_stage = ref !(t.current_stage)
+  }
 ;;
 
 let length t = Array.length t.arrs
@@ -41,24 +51,28 @@ let to_string ?(pad = "") t =
   else (
     let str =
       t.arrs
-      |> Array.mapi (fun idx arr ->
+      |> Array.mapi (fun idx (arr, pair) ->
+             let print_entry n =
+               if not pair
+               then Integer.to_string n
+               else (
+                 let upper, lower = split_integer n in
+                 Printf.sprintf
+                   "(%s, %s)"
+                   (Integer.to_string upper)
+                   (Integer.to_string lower))
+             in
              Printf.sprintf
                "%s%d : %s\n"
                (pad ^ pad)
                idx
-               (Printing.list_to_string Integer.to_string (Array.to_list arr)))
+               (Printing.list_to_string print_entry (Array.to_list arr)))
       |> Array.fold_left ( ^ ) ""
     in
     Printf.sprintf "[\n%s%s]" str pad)
 ;;
 
-let update
-    ~(stage : int)
-    ~(idx : int)
-    ~(getop : zint -> 'a)
-    ~(setop : zint -> zint)
-    (t : t)
-  =
+let validate_update stage idx t =
   if stage < 0 || idx < 0
   then failwith "Pipeline Error: Stage or index value is negative";
   if stage < !(t.current_stage)
@@ -71,7 +85,7 @@ let update
     failwith
       "Pipeline Error: Attempted to access nonexistent global. This should be \
        impossible.";
-  let arr = t.arrs.(stage) in
+  let arr, pair = t.arrs.(stage) in
   if idx >= Array.length arr
   then
     failwith
@@ -79,8 +93,44 @@ let update
          "Pipeline Error: Index %d is invalid for global number %d."
          idx
          stage;
+  arr, pair
+;;
+
+let update
+    ~(stage : int)
+    ~(idx : int)
+    ~(getop : zint -> 'a)
+    ~(setop : zint -> zint)
+    (t : t)
+  =
+  let arr, pair = validate_update stage idx t in
+  if pair
+  then failwith @@ "Pipeline Error: Tried to use Array.update on a paired array";
   let orig_val = arr.(idx) in
   arr.(idx) <- setop orig_val;
   t.current_stage := stage + 1;
   getop orig_val
+;;
+
+let update_complex
+    ~(stage : int)
+    ~(idx : int)
+    ~(memop : zint -> zint -> zint * zint * 'a)
+    (t : t)
+  =
+  let arr, pair = validate_update stage idx t in
+  let orig_val = arr.(idx) in
+  let new_val, ret =
+    match pair with
+    | true ->
+      let upper, lower = split_integer orig_val in
+      let new_upper, new_lower, ret = memop upper lower in
+      Integer.concat new_upper new_lower, ret
+    | false ->
+      let new_val, _, ret = memop orig_val (Integer.of_int 0) in
+      new_val, ret
+  in
+  arr.(idx) <- new_val;
+  t.current_stage := stage + 1;
+  ret
 ;;

--- a/src/lib/midend/interpreter/Pipeline.mli
+++ b/src/lib/midend/interpreter/Pipeline.mli
@@ -4,12 +4,13 @@ type t
 
 val empty : unit -> t
 
-(* Takes a list of (width * length) pairs -- width is the number of bits in each entry,
-   length is the number of entries *)
-val of_globals : (int * int) list -> t
+(* Takes a list of (width * length, is_pair) triple -- width is the number of bits in each entry,
+   length is the number of entries, and is_pair indicates that this is a pair array, with both halves
+   having width bits *)
+val of_globals : (int * int * bool) list -> t
 
 (* Returns a _new_ pipeline with one more stage *)
-val append_stage : width:int -> length:int -> t -> t
+val append_stage : width:int -> length:int -> pair:bool -> t -> t
 
 (* Reset stage counter to 0. Should be done at the beginning of each handler *)
 val reset_stage : t -> unit
@@ -20,7 +21,8 @@ val length : t -> int
 val to_string : ?pad:string -> t -> string
 
 (* Updates the given stage at the given index by applying setop, and returns the
-   result of getop applied to the original value. Increments stage counter. *)
+   result of getop applied to the original value. Increments stage counter. Only
+   works on non-pair arrays *)
 val update:
      stage:int
   -> idx:int
@@ -28,4 +30,13 @@ val update:
   -> setop:(zint -> zint)
   -> t
   -> 'a
-    [@@ocamlformat "disable"]
+[@@ocamlformat "disable"]
+
+(* Same as update, but takes a complex memop, and works on either kind of array *)
+val update_complex:
+     stage:int
+  -> idx:int
+  -> memop:(zint -> zint -> zint * zint * 'a)
+  -> t
+  -> 'a
+[@@ocamlformat "disable"]

--- a/src/lib/midend/interpreter/Pipeline.mli
+++ b/src/lib/midend/interpreter/Pipeline.mli
@@ -32,7 +32,7 @@ val update:
   -> 'a
 [@@ocamlformat "disable"]
 
-(* Same as update, but takes a complex memop, and works on either kind of array *)
+(* Same as update, but takes a complex memop, and works on either kind of array. *)
 val update_complex:
      stage:int
   -> idx:int

--- a/src/lib/midend/transformations/PartialInterpretation.ml
+++ b/src/lib/midend/transformations/PartialInterpretation.ml
@@ -381,9 +381,10 @@ let interp_decl env d =
     let e = interp_exp env e in
     let env = add_dec env id in
     env, { d with d = DGlobal (id, ty, e) }
-  | DMemop (id, body) ->
+  | DMemop (id, params, body) ->
     let env = add_dec env id in
-    env, { d with d = DMemop (id, interp_body env body) }
+    (* TODO: Maybe interp in the body? Maybe that's handled later? *)
+    env, { d with d = DMemop (id, params, body) }
   | DHandler (id, body) ->
     let env = add_dec env id in
     env, { d with d = DHandler (id, interp_body env body) }
@@ -397,7 +398,7 @@ let interp_prog ds = ds
    need to keep mutations which might or might not get overwritten later.
    For example, the following program prints 8 when in(1,2) is called, but should
    print 10:
-   
+
    event in(int<<8>> i, int<<8>> j) {
      int<<'a>> k = 2;
      if (j == 2) { k = 3; }

--- a/src/lib/midend/transformations/eliminateBools.ml
+++ b/src/lib/midend/transformations/eliminateBools.ml
@@ -41,14 +41,13 @@ let eliminate_complex_bool_assigns ds =
       inherit [_] s_map as super
 
       (* skip memops! *)
-      method! visit_DMemop _ id body = DMemop (id, body)
+      method! visit_DMemop _ id params body = DMemop (id, params, body)
 
       method! visit_statement ctx statement =
         match rhs_of_stmt statement.s with
         | Some exp ->
           (match is_bool_non_immediate exp with
-          | true ->
-            eliminate_complex_bool_assign statement
+          | true -> eliminate_complex_bool_assign statement
           | false -> super#visit_statement ctx statement)
         | None -> super#visit_statement ctx statement
     end
@@ -69,7 +68,7 @@ let eliminate_bool_values_and_types ds =
       inherit [_] s_map as super
 
       (* skip memops! *)
-      method! visit_DMemop _ id body = DMemop (id, body)
+      method! visit_DMemop _ id params body = DMemop (id, params, body)
       method! visit_VBool _ b = VInt (zint_of_bool b)
       method! visit_TBool _ = TInt bool_sz
     end

--- a/src/lib/midend/transformations/normalizeBools.ml
+++ b/src/lib/midend/transformations/normalizeBools.ml
@@ -162,7 +162,7 @@ module NormalizeRelops = struct
         inherit [_] s_map as super
 
         (* skip memops! *)
-        method! visit_DMemop _ id body = DMemop (id, body)
+        method! visit_DMemop _ id params body = DMemop (id, params, body)
 
         method! visit_statement ctx stmt =
           match stmt with
@@ -265,10 +265,10 @@ module NormalizeBoolExps = struct
       error
         "z3_from_expr got an ehash -- this should have been eliminated by an \
          earlier pass."
-    | (EFlood _, _) -> 
+    | EFlood _, _ ->
       error
         "z3_from_expr got an eflood -- there shouldn't be a flood constructor \
-        inside of a boolean"
+         inside of a boolean"
   ;;
 
   (* tell Z3 to convert a boolean expression into disjunctive normal form *)
@@ -375,7 +375,7 @@ module NormalizeBoolExps = struct
         inherit [_] s_map as super
 
         (* skip memops! *)
-        method! visit_DMemop _ id body = DMemop (id, body)
+        method! visit_DMemop _ id params body = DMemop (id, params, body)
 
         method! visit_statement ctx stmt =
           match stmt with

--- a/src/lib/midend/transformations/normalizeInts.ml
+++ b/src/lib/midend/transformations/normalizeInts.ml
@@ -125,7 +125,7 @@ let atomize_int_assigns ds =
       method precompute_stmts = precompute_stmts
 
       (* skip memops! *)
-      method! visit_DMemop _ id body = DMemop (id, body)
+      method! visit_DMemop _ id params body = DMemop (id, params, body)
 
       method! visit_statement ctx stmt =
         match stmt.s with

--- a/test/expected/pairarrays_output.txt
+++ b/test/expected/pairarrays_output.txt
@@ -1,0 +1,40 @@
+dpt: Parsing ...
+dpt: Auto-detected specification file examples/interp_tests/pairarrays.json
+dpt: Simulating...
+dpt: Using random seed: 0
+
+t=0: Handling event in(0,2,7) at switch 0, port 0
+18, 18, 3
+t=1000: Handling event in(1,1,2) at switch 0, port 0
+13, 13, 2
+t=2000: Handling event in(2,4,1) at switch 0, port 0
+0, 0, 1
+t=3000: Handling event in(3,30,15) at switch 0, port 0
+0, 0, 1
+t=4000: Handling event in(1,63,1) at switch 0, port 0
+0, 0, 67
+t=5000: Handling event in(2,63,2) at switch 0, port 0
+0, 0, 3
+t=6000: Handling event in(3,63,3) at switch 0, port 0
+0, 0, 3
+t=7000: Handling event in(0,63,20) at switch 0, port 0
+0, 0, 72
+dpt: Final State:
+
+Switch 0 : {
+
+ Pipeline : [
+    0 : [(4u16, 64u16); (4u16, 64u16); (4u16, 67u16); (4u16, 93u16)]
+    1 : [(4u8, 64u8); (4u8, 64u8); (4u8, 67u8); (4u8, 93u8)]
+    2 : [29u16; 5u16; 4u16; 4u16]
+  ]
+
+ Events :   [ ]
+
+ Exits :    [ ]
+
+ entry events handled: 0
+ total events handled: 8
+
+}
+dpt: Done


### PR DESCRIPTION
This PR adds a more general form of memop, as well as a new type of paired array, where each index holds two values.

This PR is mostly, but not entirely, backwards-compatible. Previously, the arguments to a memop were allowed to have different sizes; however, we now require all arguments to have the same size. The only change that needs to be made to existing programs is to tweak the parameters to any memops that took different size arguments.