### PR TITLE
initial support for egress handlers in tofino backend

### DIFF
--- a/examples/tofino_apps/src/egress_reflector.dpt
+++ b/examples/tofino_apps/src/egress_reflector.dpt
@@ -1,0 +1,20 @@
+/* Reflect the packet back out of ingress port */
+include "ip_default.dpt"
+
+event ip_pkt_out (eth_hdr eth, ip_hdr_prefix ip, int<<32>> src, int<<32>> dst);
+
+// ingress
+handle ip_pkt (eth_hdr eth, ip_hdr_prefix ip, int<<32>> src, int<<32>> dst){
+    generate_port (ingress_port, ip_pkt_out(eth, ip, src, dst));
+}
+
+// egress
+memop incr(int memval, int incrval) {
+    return memval + incrval;
+}
+global Array.t<<32>> my_egr_arr = Array.create(8);
+@egress handle ip_pkt_out (eth_hdr eth, ip_hdr_prefix ip, int<<32>> src, int<<32>> dst) {
+  // count and transform back into an ip_pkt event with count in ip src and dst
+  int x = Array.update(my_egr_arr, 0, incr, 1, incr, 1);
+  generate(ip_pkt_out(eth, {ip with tos = (int<<8>>)x}, src, dst));
+}

--- a/examples/tofino_apps/tests/egress_reflector.json
+++ b/examples/tofino_apps/tests/egress_reflector.json
@@ -1,0 +1,31 @@
+{
+    "name" : "reflect_two", 
+    "input_port": "128",
+    "packets": [
+        {
+            "ip.src" : "1.1.1.1", 
+            "ip.dst" : "2.2.2.2",
+            "ip.tos" : 0
+        },
+        {
+            "ip.src" : "2.2.2.2", 
+            "ip.dst" : "2.2.2.2",
+            "ip.tos" : 0
+        }
+    ],
+    "model-output":
+    [
+        {
+            "port" : 128,
+            "ip.src" : "1.1.1.1", 
+            "ip.dst" : "2.2.2.2",
+            "ip.tos" : 1
+        },            
+        {
+            "port" : 128,
+            "ip.src" : "2.2.2.2", 
+            "ip.dst" : "2.2.2.2",
+            "ip.tos" : 2
+        }            
+    ]
+}

--- a/src/lib/backend/tofinoCore.ml
+++ b/src/lib/backend/tofinoCore.ml
@@ -88,6 +88,8 @@ and td =
      cid list is the variables it can modify *)
   | TDOpenFunction of id * params * statement * (cid list)
 
+
+
 and main_handler = {
     main_id : id;
     hdl_selector : (id * ty);
@@ -285,8 +287,7 @@ let add_main_handler decls =
       | TDHandler(hdl_id, _, (_, stmt)) -> (
         let hdl_num = match List.assoc_opt hdl_id hdl_enum with 
           | None -> error "[generate_merged_handler] could not find handler id in enum. Do events and handlers have the same internal IDs?"
-          | Some hdl_num -> 
-            hdl_num
+          | Some hdl_num -> hdl_num
         in 
         branches@[([PNum (Z.of_int(hdl_num))], stmt)]
       )

--- a/src/lib/backend/tofinoEgress.ml
+++ b/src/lib/backend/tofinoEgress.ml
@@ -1,0 +1,123 @@
+open CoreSyntax
+
+(* egress pipeline processing *)
+let has_egress (ds:decl list) =
+  let check_decl d =
+    match d.d with
+    | DHandler(_, HEgress, _) -> true
+    | _ -> false
+  in
+  List.exists check_decl ds
+;;
+
+(* find all the globals in the program *)
+let find_globals ds =
+  let global_ids = ref [] in
+  let v =
+    object
+      inherit [_] s_iter as super
+      method! visit_decl _ decl =
+        match decl.d with
+        | DGlobal(id, _, _) -> 
+          print_endline (CorePrinting.decl_to_string (decl));
+          global_ids := id::(!global_ids);
+        | DAction({aid=aid; _}) -> 
+          global_ids := aid::(!global_ids);
+        | _ -> ()
+    end
+  in
+  v#visit_decls () ds;
+  !global_ids
+;;
+
+(* get all the globals referenced by the handler *)
+let find_globals_in_decl (globals : cid list) dhandler =
+  let globals_in_dhandler = ref [] in
+  let v =
+    object
+      inherit [_] s_iter as super
+      method! visit_EVar _ (c:cid) =
+        if List.mem c globals && not (List.mem c !globals_in_dhandler) then
+          globals_in_dhandler := c :: !globals_in_dhandler
+    end
+  in
+  v#visit_decl () dhandler;
+  !globals_in_dhandler  
+;;
+
+(* find all the globals used in handlers of sort "handler_sort" *)
+let find_globals_in_handler_sort handler_sort decls =
+  let all_globals = find_globals decls |> List.map Cid.id in
+  List.fold_left (fun handler_globals decl ->
+    match decl.d with
+    | DHandler (_, sort, _) when sort = handler_sort ->
+        let handler_globals = find_globals_in_decl all_globals decl in
+        List.concat [handler_globals; handler_globals]
+    | _ -> handler_globals
+  ) [] decls
+;;
+
+let egress_uses_disjoint_globals decls : bool =
+  (* check to see whether there is overlap in the 
+     globals used by handlers of sort HEgress and
+     handlers of sort HData *)
+  let egress_globals = find_globals_in_handler_sort HEgress decls in
+  let data_globals = find_globals_in_handler_sort HData decls in
+  List.for_all (fun g -> not (List.mem g data_globals)) egress_globals
+;;
+
+let split_decls decls : (decl list * decl list ) =
+  (* 1. check to make sure that egress handlers use different globals 
+        than all other handlers. If they do not, print an error message and then exit.
+     2. split the list of declarations into 2 components: 
+        1. an egress_decls list of all handlers of type HEgress 
+        and all the global variable declarations they use, 
+        and all shared decls.
+        2. an ingress_decls list of all handlers of type HData
+        and all the global variable declarations they use, 
+        and all shared decls. *)
+  (* no egress means everything is an ingress decl *)
+  if (not (has_egress decls)) then (decls, []) else (
+    if (not (egress_uses_disjoint_globals decls)) then begin
+      print_endline "Error: Egress handlers use globals accessed by ingress handlers.";
+      exit 1
+    end;
+    let egress_globals = find_globals_in_handler_sort HEgress decls in
+    let ingress_globals = find_globals_in_handler_sort HData decls in
+    let egr_decls, igr_decls = List.fold_left 
+      (fun (egress_acc, ingress_acc) decl ->
+        match decl.d with
+        | DHandler(_, HEgress, _) -> (decl :: egress_acc, ingress_acc)
+        | DHandler(_, HData, _) ->   (egress_acc, decl :: ingress_acc)
+        | DGlobal(id, _, _) -> 
+          if (List.mem (Cid.id id) egress_globals)
+          then ((decl :: egress_acc, ingress_acc))
+          else (
+            if (List.mem (Cid.id id) ingress_globals)
+            then ((egress_acc, decl :: ingress_acc))
+            else ((decl :: egress_acc, decl :: ingress_acc)))
+        | _ -> ((decl :: egress_acc, decl :: ingress_acc))
+      ) 
+      ([], []) 
+      decls
+    in
+    igr_decls, egr_decls)
+;;
+
+(* Add a command to set the drop flag to the beginning of every egress handler. *)
+let egr_drop_ctl_id = Id.create "drop_ctl";;
+let egr_drop_ctl_sz = 3
+let rec add_default_egr_drop ds = 
+  let set_drop_ctl = sassign egr_drop_ctl_id (vint_exp 1 egr_drop_ctl_sz) in
+  let prepend_set_drop_ctl body =
+    match body with
+    | (params, stmt) -> (params, { stmt with s = SSeq(set_drop_ctl, stmt) })
+  in
+  let update_handler handler =
+    match handler.d with
+    | DHandler(id, HEgress, body) -> { handler with d = DHandler(id, HEgress, prepend_set_drop_ctl body) }
+    | _ -> handler
+  in
+  List.map update_handler ds
+;;
+

--- a/src/lib/backend/tofinoProfiling.ml
+++ b/src/lib/backend/tofinoProfiling.ml
@@ -1,4 +1,5 @@
 (* use the backend to estimate resource utilization on the tofino *)
+(* NOTE: this is only for the ingress pipeline!  *)
 open TofinoCore
 
 let info str = 
@@ -13,7 +14,7 @@ let export_dfg ds dfg_json_fn =
   let ds = ds 
     |> TofinoPipeline.common_midend_passes 
     |> tdecls_of_decls
-    |> (TofinoPipeline.tofinocore_normalization true) 
+    |> (TofinoPipeline.tofinocore_normalization true true) 
   in
   ExternalLayout.export ds dfg_json_fn;
 ;;
@@ -25,7 +26,7 @@ let profile ds portspec output_dir profile_cmd =
   let ds = ds 
     |> TofinoPipeline.common_midend_passes 
     |> tdecls_of_decls
-    |> (TofinoPipeline.tofinocore_normalization true) 
+    |> (TofinoPipeline.tofinocore_normalization true true) 
   in
   (* now profile the resulting program *)
   match profile_cmd with 

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -114,6 +114,7 @@
    TofinoCore
    TofinoCoreForms
    TofinoControl
+   TofinoEgress
    InlineEventVars
    SolitaryMatches
    Generates

--- a/src/lib/frontend/Lexer.mll
+++ b/src/lib/frontend/Lexer.mll
@@ -64,6 +64,7 @@ rule token = parse
   | "auto"            { AUTO (position lexbuf) }
   | "group"           { GROUP (position lexbuf) }
   | "control"         { CONTROL (position lexbuf) }
+  | "@egress"         { EGRESS (position lexbuf) }
   | "entry"           { ENTRY (position lexbuf) }
   | "exit"            { EXIT (position lexbuf) }
   | "match"           { MATCH (position lexbuf) }

--- a/src/lib/frontend/Parser.mly
+++ b/src/lib/frontend/Parser.mly
@@ -118,6 +118,7 @@
 %token <Span.t> AUTO
 %token <Span.t> GROUP
 %token <Span.t> CONTROL
+%token <Span.t> EGRESS
 %token <Span.t> ENTRY
 %token <Span.t> EXIT
 %token <Span.t> MATCH
@@ -367,6 +368,7 @@ event_decl:
 handle_sort: 
     | HANDLE         {$1, HData}
     | CONTROL HANDLE {$1, HControl}
+    | EGRESS HANDLE  {$1, HEgress}
 
 tyname_def:
     | ID                                  { snd $1, [] }

--- a/src/lib/frontend/Printing.ml
+++ b/src/lib/frontend/Printing.ml
@@ -508,7 +508,8 @@ and d_to_string d =
     Printf.sprintf
       "%shandle %s(%s) {\n%s\n}"
       (match hsort with 
-        | HControl -> "control " | HData -> "")
+        | HControl -> "control " | HData -> ""
+        | HEgress -> "@egress")
       (id_to_string id)
       (params_to_string params)
       (stmt_to_string s)

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -236,9 +236,11 @@ and event_sort =
   | EExit       (* events that leave the lucid program *)
   | EBackground (* standard event sort *)
 
+(* this is really a location where the handler executes *)
 and handler_sort = 
   | HControl (* control processor *)
   | HData (* data processor *)
+  | HEgress (* egress pipeline *)
 
 and ispec =
   | InSize of id

--- a/src/lib/midend/CorePrinting.ml
+++ b/src/lib/midend/CorePrinting.ml
@@ -332,7 +332,7 @@ let d_to_string d =
     Printf.sprintf
       "%shandle %s(%s) {\n%s\n}"
       (match hsort with 
-        | HControl -> "control " | HData -> "")
+        | HControl -> "control " | HData -> "" | HEgress -> "@egress ")
       (id_to_string id)
       (params_to_string params)
       (stmt_to_string s)

--- a/src/lib/midend/CoreSyntax.ml
+++ b/src/lib/midend/CoreSyntax.ml
@@ -157,6 +157,13 @@ and s =
   | STableMatch of tbl_match
   | STableInstall of exp * tbl_entry list
 
+
+and statement =
+  { s : s
+  ; sspan : sp
+  ; spragma : pragma option;
+  }
+
 and tbl_match_out_param = (id * (ty option))
 
 and tbl_match = 
@@ -179,11 +186,6 @@ and tbl_entry = {
 
 and pragma = string * string list
 
-and statement =
-  { s : s
-  ; sspan : sp
-  ; spragma : pragma option;
-  }
 
 and params = (id * ty) list
 
@@ -192,6 +194,7 @@ and body = params * statement
 and handler_sort = 
   | HControl
   | HData
+  | HEgress
 
 and event_sort =
   | EEntry of bool (* true iff "control", i.e. it can generate non-continue events *)

--- a/src/lib/midend/transformations/SyntaxToCore.ml
+++ b/src/lib/midend/transformations/SyntaxToCore.ml
@@ -236,6 +236,7 @@ let translate_sort = function
 let translate_hsort = function
   | S.HControl -> C.HControl
   | S.HData -> C.HData
+  | S.HEgress -> C.HEgress
 
 let translate_decl (d : S.decl) : C.decl =
   let d' =

--- a/test/backend/testspecs/tested_examples.json
+++ b/test/backend/testspecs/tested_examples.json
@@ -2,6 +2,7 @@
     "base_dir":"examples/tofino_apps",
     "builds_dir":"__testbuilds",
     "tests": [
+        {"commands":["compile", "assemble", "execute"], "prog":"src/egress_reflector.dpt","build":"egress_reflector", "testspec":"tests/egress_reflector.json"},
         {"commands":["compile", "assemble", "execute"], "prog":"src/complex_memops.dpt","build":"complex_memops", "testspec":"tests/complex_memops.json"},
         {"commands":["compile", "assemble", "execute"], "prog":"src/multi_events.dpt", "build":"multi_events", "testspec":"tests/multi_events.json"},
         {"commands":["compile", "assemble", "execute"], "prog":"src/r_after_w.dpt", "build":"r_after_w", "testspec":"tests/r_after_w.json"},


### PR DESCRIPTION
egress handlers in the tofino backend. Prefix a handler declaration with @egress to make the handler execute in the egress pipeline. Notes: egress handlers may not access globals accessed by non-egress handlers; currently, each event may only have one handler; if an egress event arrives at a switch ingress, it will be dropped; egress handlers are not implemented in the interpreter yet, it just ignores the @egress tag for now.

TODO: make sure egress handler semantics are defined completely; add more test cases; add support in the interpreter (possibly by transforming egress events into self events that carry output port / group ids)