### PR TITLE
Unordered global operations

### DIFF
--- a/src/lib/backend/tofino/analysis/InputChecks.ml
+++ b/src/lib/backend/tofino/analysis/InputChecks.ml
@@ -54,7 +54,7 @@ let array_sizes ds : bool =
         | DGlobal
             ( id
             , { raw_ty = TName (ty_cid, sizes, true); _ }
-            , { e = ECall (_, num_slots :: _) } ) ->
+            , { e = ECall (_, num_slots :: _, _) } ) ->
           (match Cid.names ty_cid |> List.hd with
            | "Array" ->
              let slot_sz = List.hd sizes in
@@ -288,8 +288,8 @@ let align_ecalls ds =
       method! visit_exp ctx exp =
         let exp = super#visit_exp ctx exp in
         match exp.ety.raw_ty, exp.e with
-        | TEvent, ECall (ev_cid, args) ->
-          { exp with e = ECall (ev_cid, align_args args) }
+        | TEvent, ECall (ev_cid, args, u) ->
+          { exp with e = ECall (ev_cid, align_args args, u) }
         | _ -> exp
     end
   in

--- a/src/lib/backend/tofino/core/AddIngressParser.ml
+++ b/src/lib/backend/tofino/core/AddIngressParser.ml
@@ -108,7 +108,7 @@ let inline_parser = object (_)
          match parser_block.pstep with
          | (PCall(exp), _) -> (
             match exp.e with 
-            | ECall(called_cid, eargs) -> (
+            | ECall(called_cid, eargs, _) -> (
                (* first replace params with args *)
                let params, called_body_block = CidMap.find called_cid ctx in
                let (subst_map: e CidMap.t) = List.fold_left2
@@ -247,7 +247,7 @@ let direct_call_parser_block parser_block =
    let {pactions=acns_spans; pstep=(step, _);} = parser_block in
    let acns, _ = List.split acns_spans in
    match acns, step with 
-   | [], PCall({e=ECall(cid, _); _}) when (Id.equal Builtins.lucid_parse_id (Cid.to_id cid)) -> true
+   | [], PCall({e=ECall(cid, _, _); _}) when (Id.equal Builtins.lucid_parse_id (Cid.to_id cid)) -> true
    | _ -> false 
 ;;
 (* a direct call parser branch is one that matches a single variable and 
@@ -263,7 +263,7 @@ let never_calls_lucid_parser branch =
       inherit [_] s_iter as super
       method! visit_PCall _ exp = 
          match exp.e with 
-            | ECall(cid, _)
+            | ECall(cid, _, _)
                when (Id.equal Builtins.lucid_parse_id (Cid.to_id cid)) -> 
                   call_found := true
             | _ -> ()
@@ -324,7 +324,7 @@ let check_valid_entry_parse_block parse_block : lucid_entry_block_ty =
    let acns, _ = List.split acns_spans in 
    match acns, step with
    (* parser main() { do_lucid_parsing(); } *)
-   | [], PCall({e=ECall(cid, _); _}) when cid_is_ingress_port cid -> 
+   | [], PCall({e=ECall(cid, _, _); _}) when cid_is_ingress_port cid -> 
       CallAlways
    (* parser main() { match ingress_port with <branches>, where branches 
       either directly call the lucid parser or never call the lucid parser } *)

--- a/src/lib/backend/tofino/core/EliminateEventCombinators.ml
+++ b/src/lib/backend/tofino/core/EliminateEventCombinators.ml
@@ -15,7 +15,7 @@ let rec process ds =
       method! visit_exp ctx exp =
         let exp = super#visit_exp ctx exp in
         match exp.e with
-        | ECall(fcn_cid, args) -> (
+        | ECall(fcn_cid, args, _) -> (
           match Cid.names fcn_cid with
           | "Event"::"delay"::_ -> (
             warn@@"removing event delay combinator in ("^(CorePrinting.exp_to_string exp)^" -- not yet supported";

--- a/src/lib/backend/tofino/core/EliminateGenerates.ml
+++ b/src/lib/backend/tofino/core/EliminateGenerates.ml
@@ -323,7 +323,7 @@ let rec enable_event_headers ev =
     | SGen(gty, exp) -> (
       (* ingress_out.foo.bar, [1, 2, 3] *)
       let ctor_cid, args = match exp.e with
-        | ECall(cid, args) -> cid, args
+        | ECall(cid, args, _) -> cid, args
         | _ -> error "[EliminateGenerates] event expression inside of a generate must be a constructor expression"
       in
       (* replace the generate statement with a sequence of assignments. *)
@@ -431,7 +431,7 @@ let rec enable_event_headers ev =
     | SGen(_, exp) -> (
       (* ingress_out.foo.bar, [1, 2, 3] *)
       let ctor_cid, args = match exp.e with
-        | ECall(cid, args) -> cid, args
+        | ECall(cid, args, _) -> cid, args
         | _ -> error "[EliminateGenerates] event expression inside of a generate must be a constructor expression"
       in    
       (* replace the generate statement with a sequence of assignments. *)

--- a/src/lib/backend/tofino/core/EliminatePayloads.ml
+++ b/src/lib/backend/tofino/core/EliminatePayloads.ml
@@ -16,7 +16,7 @@ let pre_check ds =
     inherit [_] s_iter as super
     method! visit_exp _ exp = 
       match exp.e with
-      | ECall(cid, _) when (Cid.equal cid Payloads.payload_empty_cid) -> 
+      | ECall(cid, _, _) when (Cid.equal cid Payloads.payload_empty_cid) -> 
         CoreSyntax.error ("The Payload.empty() function is not supported on the tofino.")
       | _ -> super#visit_exp () exp
     end
@@ -37,11 +37,11 @@ let rec process ds =
         params
       method! visit_exp ctx exp = 
         match exp.e with
-        | ECall(cid, args) ->
+        | ECall(cid, args, u) ->
           (* delete any args with payload type *)
           let args = List.filter args ~f:(fun arg -> 
             not (InterpPayload.is_payload_ty arg.ety)) in
-          { exp with e = ECall(cid, args) }
+          { exp with e = ECall(cid, args, u) }
         | _ -> super#visit_exp ctx exp
     end
   in

--- a/src/lib/backend/tofino/core/IfToMatch.ml
+++ b/src/lib/backend/tofino/core/IfToMatch.ml
@@ -638,7 +638,7 @@ let match_of_if_new exp s1 s2 =
     let stmt_list = unfold_stmts stmt in
     let branch_votes = CL.map 
       (fun stmt -> (match stmt.s with
-        | SUnit({e=ECall(_, [{e=EVal({v=VBool branch_bool})}])}) -> branch_bool
+        | SUnit({e=ECall(_, [{e=EVal({v=VBool branch_bool})}], _)}) -> branch_bool
         | _ -> error "[match_of_if_new] unexpected statement in branch of merged match"))
       stmt_list
     in

--- a/src/lib/backend/tofino/core/InlineEventVars.ml
+++ b/src/lib/backend/tofino/core/InlineEventVars.ml
@@ -155,7 +155,7 @@ let inline_event_vars (ds:decls) =
           | TEvent -> (
             match exp.e with 
             (* set event var to value --  bind *)
-            | ECall(ev_cid, ev_args) -> (
+            | ECall(ev_cid, ev_args, u) -> (
               (* create new variables that are copies of args 
                  at event var decl time. Create var exps and assign stmts. *)
               let ev_args, arg_assignments = List.mapi
@@ -169,7 +169,7 @@ let inline_event_vars (ds:decls) =
               |> List.split
               in
               (* use copy variables as event arguments *)
-              let exp = {exp with e=ECall(ev_cid, ev_args)} in 
+              let exp = {exp with e=ECall(ev_cid, ev_args, u)} in 
               (* bind the updated event exp *)
               ev_calls := (cid, exp)::(!ev_calls);
               (* return statements to set copy variables instead of setting event*)
@@ -194,7 +194,7 @@ let inline_event_vars (ds:decls) =
           | TEvent -> (
             match exp.e with 
             (* set event var to value --  bind *)
-            | ECall(ev_cid, ev_args) -> (
+            | ECall(ev_cid, ev_args, u) -> (
               (* create new variables that are copies of args 
                  at event var decl time. Create var exps and assign stmts. *)
               let ev_args, arg_assignments = List.mapi
@@ -208,7 +208,7 @@ let inline_event_vars (ds:decls) =
               |> List.split
               in
               (* use copy variables as event arguments *)
-              let exp = {exp with e=ECall(ev_cid, ev_args)} in 
+              let exp = {exp with e=ECall(ev_cid, ev_args, u)} in 
               (* bind the updated event exp *)
               ev_calls := (cid, exp)::(!ev_calls);
               (* return statements to set copy variables instead of setting event*)
@@ -308,7 +308,7 @@ let empty_ctx = {event_constrs = []; event_vars = []};;
 
 let evconstr_of_exp ctx exp = 
   match exp.e with 
-  | ECall(cid, args) -> (
+  | ECall(cid, args, _) -> (
     match List.assoc_opt cid ctx.event_constrs with
     | Some(constr) -> Some(constr, args)
     | None -> None
@@ -432,7 +432,7 @@ let evconstr_num ctx constr_cid =
 let rec inline_stmt ctx stmt = 
   let elim_ev_var_update cid exp = 
     match exp.ety.raw_ty, exp.e  with
-    | TEvent, ECall(constr_cid, args) -> 
+    | TEvent, ECall(constr_cid, args, _) -> 
       (* update the context, adding the constructor to the event *)
       let ctx = add_constr ctx cid constr_cid in
       (* set tag and params from constructor  *)

--- a/src/lib/backend/tofino/core/RegularizeMemops.ml
+++ b/src/lib/backend/tofino/core/RegularizeMemops.ml
@@ -232,7 +232,7 @@ let regularize_array_calls tds =
         method! visit_exp ctx exp = 
           let exp = super#visit_exp ctx exp in 
           let results = match exp.e with 
-            | ECall(fcn_cid, args) -> (
+            | ECall(fcn_cid, args, _) -> (
               match (string_of_fcncid fcn_cid) with 
               | "Array.getm" -> (
                 let aid, idx, get_memop, get_arg = match args with
@@ -258,7 +258,7 @@ let regularize_array_calls tds =
                   (CS.default_vint memop_size |> value_to_exp)
                   ]
                 in
-                let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args) in 
+                let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args, false) in 
                 Some ({exp with e = complex_call;}, complex_memop, old_memop_ids)
               )
             | "Array.get" ->  
@@ -283,7 +283,7 @@ let regularize_array_calls tds =
                   (CS.default_vint memop_size |> value_to_exp)
                   ]
               in
-              let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args) in 
+              let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args, false) in 
               Some ({exp with e = complex_call;}, complex_memop, [])
               | "Array.setm" -> 
                 let aid, idx, set_memop, set_arg = match args with
@@ -312,7 +312,7 @@ let regularize_array_calls tds =
                   (CS.default_vint memop_size |> value_to_exp)
                   ]
                 in
-                let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args) in 
+                let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args, false) in 
                 Some ({exp with e = complex_call;}, complex_memop, old_memop_ids)
               | "Array.set" -> 
                 let aid, idx, set_arg = match args with
@@ -336,7 +336,7 @@ let regularize_array_calls tds =
                     (CS.default_vint memop_size |> value_to_exp)
                     ]
                 in
-                let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args) in 
+                let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args, false) in 
                 Some ({exp with e = complex_call;}, complex_memop, [])
 
               | "Array.update" -> (
@@ -366,7 +366,7 @@ let regularize_array_calls tds =
                   (CS.default_vint memop_size |> value_to_exp)
                   ]
                 in
-                let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args) in 
+                let complex_call = CS.ECall ((Cid.create ["Array"; "update_complex"]), complex_args, false) in 
                 Some ({exp with e = complex_call;}, complex_memop, old_memop_ids)
               )
               | _ -> None

--- a/src/lib/backend/tofino/layout/TofinoDfg.ml
+++ b/src/lib/backend/tofino/layout/TofinoDfg.ml
@@ -100,7 +100,7 @@ let rec read_ids_of_exp exp : Cid.t list =
   match exp.e with 
   | EVar(cid) -> [cid]
   | EOp(_, args)
-  | ECall(_, args)
+  | ECall(_, args, _)
   | EHash(_, args) ->
     List.map read_ids_of_exp args |> List.flatten
   | EFlood(arg) -> read_ids_of_exp arg
@@ -140,7 +140,7 @@ let rec read_ids_of_stmt (stmt:CoreSyntax.statement) : Cid.t list =
   (* invalidate call _writes_ to its arg fields *)
   | SUnit(exp) -> (
     match exp.e with 
-    | ECall(fcn_cid, _) -> (
+    | ECall(fcn_cid, _, _) -> (
       match Cid.names fcn_cid with 
       | "Sys"::"invalidate"::_ -> []
       | _ -> read_ids_of_exp exp
@@ -179,7 +179,7 @@ let rec write_ids_of_stmt (stmt:CoreSyntax.statement) : (Cid.t list) =
   (* an invalidate call writes to its fields *)
   | SUnit(exp) -> (
     match exp.e with 
-    | ECall(fcn_cid, args) -> (
+    | ECall(fcn_cid, args, _) -> (
       match Cid.names fcn_cid with 
       | "Sys"::"invalidate"::_ -> (
         List.map (fun arg_exp -> 

--- a/src/lib/backend/tofino/layout/TofinoLayout.ml
+++ b/src/lib/backend/tofino/layout/TofinoLayout.ml
@@ -365,7 +365,7 @@ let hashers_of_table_stmt salu_idx_vars stmt =
   let v = object
     inherit [_] s_iter as super
     (* count hashes in array ops *)
-    method! visit_ECall _ fid args = 
+    method! visit_ECall _ fid args _ = 
       match (Cid.names fid) with
         | ["Sys"; "random"] -> (
           error "todo: count random as using hash unit"

--- a/src/lib/backend/tofino/layout/TofinoResources.ml
+++ b/src/lib/backend/tofino/layout/TofinoResources.ml
@@ -17,7 +17,7 @@ let arrays_of_exp exp =
     Caml.String.concat "." @@ Cid.names cid 
   in
   match exp.e with 
-  | ECall(fid, args) -> (
+  | ECall(fid, args, _) -> (
     match (string_of_fcncid fid) with 
       | "Array.get"| "Array.getm" | "Array.set"
       | "Array.setm" | "Array.update" 
@@ -77,7 +77,7 @@ let sblocks_of_stmt arr_info stmt =
 let rec hashers_of_exp exp = 
   match exp.e with 
   | EOp(_, es) -> List.map hashers_of_exp es |> List.flatten
-  | ECall(fcn_cid, es) -> (
+  | ECall(fcn_cid, es, _) -> (
     match (Cid.names fcn_cid) with
     | "Sys"::"random"::_ -> 
       exp::(List.map hashers_of_exp es |> List.flatten)
@@ -154,7 +154,7 @@ let calc_salu_hash_bits ty = min 22 (ty_to_size ty)
 (* count the number of hash alus needed to implement an expression *)
 let rec hash_ops_of_exp exp = match exp.e with 
 | EOp(_, es) -> hash_ops_of_exps es
-| ECall(fcn_cid, es) -> (
+| ECall(fcn_cid, es, _) -> (
   match (Cid.names fcn_cid) with
     | "Sys"::"random"::_ -> 
       calc_hash_bits_block exp.ety + (hash_ops_of_exps es)
@@ -269,7 +269,7 @@ let rec hash_ops_of_stmt statement_cache stmt =
 (* array address expressions *)
 let array_addrs_of_exp exp = 
   match exp.e with 
-  | ECall(fid, args) -> (
+  | ECall(fid, args, _) -> (
     match (Cid.names fid) with
     (* for any array function, get the index/address expression,
        which is always the 2nd argument *)

--- a/src/lib/backend/tofino/p4/TofinoCoreToP4.ml
+++ b/src/lib/backend/tofino/p4/TofinoCoreToP4.ml
@@ -90,7 +90,7 @@ let translate_pat pat =
 ;;
 let translate_sunit_ecall stmt =
   match stmt.s with 
-  | SUnit({e=ECall(acn_id, _); _}) -> sunit (ecall acn_id [])
+  | SUnit({e=ECall(acn_id, _, _); _}) -> sunit (ecall acn_id [])
   | _ -> error "[translate_branch] branch statement must be a method call to a labeled block, which represents an action"
 ;;
 let translate_branch complete_branches 
@@ -256,7 +256,7 @@ let fst_snd ((_, y), _) = y
 
 let rec translate_exp (prog_env:prog_env) exp : (T.decl list * T.expr) * prog_env =
   match exp.e with 
-  | ECall(fcn_cid, args) ->  translate_ecall prog_env fcn_cid args
+  | ECall(fcn_cid, args, _) ->  translate_ecall prog_env fcn_cid args
   | CS.EHash (size, args) -> translate_hash prog_env size args 
   | CS.EVal v -> 
     ([], T.eval_ty_sp (translate_value v.v) (translate_ty exp.ety) exp.espan), prog_env
@@ -754,7 +754,7 @@ let stmt_to_table env (_:pragma) (ignore_pragmas: (id * pragma) list) (tid, stmt
   in *)
   let action_cid_of_branch (_, stmt) =
     match stmt.s with
-      | SUnit({e=ECall(acn_id, _); _}) -> acn_id  
+      | SUnit({e=ECall(acn_id, _, _); _}) -> acn_id  
       | _ -> error "[action_id_of_branch] branch does not call an action function"
   in
   match stmt.s with
@@ -1497,7 +1497,7 @@ let translate_parser denv parser =
       smatch exps' branches'
     )
     | PGen _ -> error "[translate_parser_step] pgens should have been elminiateasd"
-    | PCall({e=CS.ECall(fcid, _)}) -> 
+    | PCall({e=CS.ECall(fcid, _, _)}) -> 
       if ((Cid.names fcid |> List.hd) = "exit")
         then transition_accept
         else error "[translate_parser_step] the only supported call is to exit/accept"
@@ -1605,7 +1605,7 @@ let translate_tdecl (denv : translate_decl_env) tdecl : (translate_decl_env) =
     | TName(tcid, [cell_size], true) -> (
         let module_name = List.hd (Cid.names tcid) in 
         let len, default_opt = match exp.e with 
-          | ECall(_, args) -> (
+          | ECall(_, args, _) -> (
             match (translate_exps denv.penv args |> fst_snd) with 
             | [elen; edefault] -> elen, Some(edefault)
             | [elen] -> elen, None

--- a/src/lib/backend/tofino/tofinocore/AddHandlerTypes.ml
+++ b/src/lib/backend/tofino/tofinocore/AddHandlerTypes.ml
@@ -103,7 +103,7 @@ let derive_output_event (ctx:ctx) (hdl_id : id) (hdl_body:statement) : event =
   (* At this point, each generate expression should be an ecall, where the id 
      is the id of the event that it generates. We get that list of event ids. *)
   let event_ids = List.map (fun (_, exp) -> match exp.e with
-    | ECall (cid, _) -> Cid.to_id cid
+    | ECall (cid, _, _) -> Cid.to_id cid
     | _ -> error "[addHandlerTypes.derive_output_type] generate expression should be an ecall") 
     generates 
   in
@@ -332,13 +332,13 @@ let scope_event_constructors (output_event : event) (hdl_body : statement) =
          (type: event; variant: ECall(evcid, evargs)); *)
       let econs_transformer exp = 
         match exp.e, exp.ety.raw_ty with
-        | (ECall(evcid, evargs), TEvent) -> (
+        | (ECall(evcid, evargs, u), TEvent) -> (
           (* this is an event constructor. The new name is 
              the old name, with the output event id prefixed. *)
           let evcid' = Cid.compound (id_of_event output_event) evcid in
           (* check to make sure the new name is valid *)
           if (ensure_event_defines_econs output_event evcid')
-            then {exp with e=ECall(evcid', evargs)}
+            then {exp with e=ECall(evcid', evargs, u)}
             else error "[addHandlerTypes.scope_event_constructors] event constructor not defined in output event."
         )
         (* non-event-constructor expressions: do nothing. *)

--- a/src/lib/backend/tofino/tofinocore/MergeHandlers.ml
+++ b/src/lib/backend/tofino/tofinocore/MergeHandlers.ml
@@ -45,10 +45,10 @@ let scope_pgen =
     method !visit_PGen (merged_hdl_event, _) exp =
       (* generates set parameters in the hdl input / parser output event *)
       let exp' = match exp.e with 
-        | ECall(ev_cid, ev_params) -> 
+        | ECall(ev_cid, ev_params, u) -> 
           {exp with e = ECall (
             Cid.compound (merged_hdl_event) ev_cid, 
-            ev_params)}
+            ev_params, u)}
         | _ -> exp
       in
       PGen(exp')

--- a/src/lib/backend/tofino/tofinocore/ParserHoisting.ml
+++ b/src/lib/backend/tofino/tofinocore/ParserHoisting.ml
@@ -99,7 +99,7 @@ and elim_parser_inner output_event (vars_read : cids) (pactions : paction_sps) (
       (* a generate step. We want to replace this generate with assign statements as necessary
          for all the variables in the arguments that will not be hoisted. *)
       match exp.e with 
-      | ECall(base_event_cid, eargs) -> (
+      | ECall(base_event_cid, eargs, _) -> (
         (* build an assoc list from args to parameters *)
         let params = scoped_params_of_evconstr output_event base_event_cid in 
         let hoist_cmds, gen_assigns = List.fold_left2

--- a/src/lib/backend/tofino/tofinocore/TofinoCore.ml
+++ b/src/lib/backend/tofino/tofinocore/TofinoCore.ml
@@ -389,7 +389,7 @@ let id_of_generate statement =
   match statement.s with
   | SGen(_, exp) -> (
     match exp.e with
-    | ECall(cid, _) -> Cid.to_id cid
+    | ECall(cid, _, _) -> Cid.to_id cid
     | _ -> error "[id_of_generate] event variables are not yet supported in generates."
   )
   | _ -> error "[id_of_generate] expected generate statement."
@@ -418,7 +418,7 @@ let array_dimensions tds =
       | TDGlobal
           ( id
           , { raw_ty = TName (ty_cid, sizes, true); _ }
-          , { e = ECall (_, num_slots :: _) } ) ->
+          , { e = ECall (_, num_slots :: _, _) } ) ->
         (match Cid.names ty_cid |> List.hd with
          | "Array" ->
            let num_slots = InterpHelpers.int_from_exp num_slots in

--- a/src/lib/frontend/Cmdline.ml
+++ b/src/lib/frontend/Cmdline.ml
@@ -34,6 +34,8 @@ type config =
   ; mutable optimal_memop_input_alloc : bool
     (* find an allocation of memop inputs to sALU input register that requires no extra copy operations.
        In some cases, this may create larger PHV clusters. *)
+  ; mutable unordered : bool 
+  
   }
 
 (* TODO: We might want to add more parameters controlling which transformations
@@ -64,6 +66,7 @@ let default () =
   ; ctl_fn = None
   ; serverlib = false
   ; optimal_memop_input_alloc = true
+  ; unordered = false
   }
 ;;
 let cfg = default ()
@@ -97,6 +100,7 @@ let parse_common () =
     cfg.verbose <- false
   in
   let set_serverlib () = cfg.serverlib <- true in
+  let set_unordered () = cfg.unordered <- true in 
   let speclist =
     [ ( "--silent"
       , Arg.Unit unset_verbose
@@ -145,8 +149,12 @@ let parse_common () =
     ; ( "--serverlib"
       , Arg.Unit set_serverlib
       , "If true, generate the python event library generator" ) 
+    ; ( "--unordered"
+      , Arg.Unit set_unordered
+      , "If true, ignore all global ordering in the effects system.")
       ]
   in
+
   speclist
 ;;
 

--- a/src/lib/frontend/Cmdline.ml
+++ b/src/lib/frontend/Cmdline.ml
@@ -34,7 +34,6 @@ type config =
   ; mutable optimal_memop_input_alloc : bool
     (* find an allocation of memop inputs to sALU input register that requires no extra copy operations.
        In some cases, this may create larger PHV clusters. *)
-  ; mutable unordered : bool 
   
   }
 
@@ -66,7 +65,6 @@ let default () =
   ; ctl_fn = None
   ; serverlib = false
   ; optimal_memop_input_alloc = true
-  ; unordered = false
   }
 ;;
 let cfg = default ()
@@ -100,7 +98,6 @@ let parse_common () =
     cfg.verbose <- false
   in
   let set_serverlib () = cfg.serverlib <- true in
-  let set_unordered () = cfg.unordered <- true in 
   let speclist =
     [ ( "--silent"
       , Arg.Unit unset_verbose
@@ -149,9 +146,6 @@ let parse_common () =
     ; ( "--serverlib"
       , Arg.Unit set_serverlib
       , "If true, generate the python event library generator" ) 
-    ; ( "--unordered"
-      , Arg.Unit set_unordered
-      , "If true, ignore all global ordering in the effects system.")
       ]
   in
 

--- a/src/lib/frontend/GlobalConstructorTagging.ml
+++ b/src/lib/frontend/GlobalConstructorTagging.ml
@@ -83,7 +83,7 @@ let rec globals_of_econstr user_constrs parent_tcid var_tcid constr_exp : (exp) 
   let var_tcid = {var_tcid with tparent=parent_tcid;} in
   (* let annotated_constr_exp = annotate_espan constr_exp parent_tcid var_tcid in *)
   match constr_exp.e with
-  | ECall(constr_cid, _) -> (
+  | ECall(constr_cid, _, _) -> (
 (*     print_endline ("[globals_of_econstr.ECall]");
     print_endline ("[globals_of_econstr.INPUT] "^(annotated_exp_to_string annotated_constr_exp)); *)
     match (Cid.names constr_cid) with

--- a/src/lib/frontend/Lexer.mll
+++ b/src/lib/frontend/Lexer.mll
@@ -63,6 +63,7 @@ rule token = parse
   | "return"          { RETURN (position lexbuf)}
   | "size"            { SIZE (position lexbuf) }
   | "global"          { GLOBAL (position lexbuf) }
+  | "unordered"       { UNORDERED (position lexbuf) }
   | "const"           { CONST (position lexbuf) }
   | "extern"          { EXTERN (position lexbuf) }
   | "void"            { VOID (position lexbuf) }

--- a/src/lib/frontend/Memops.ml
+++ b/src/lib/frontend/Memops.ml
@@ -154,7 +154,7 @@ let classify_stmts (body : statement) : (complex_stmt * sp) list =
     let ret =
       match s.s with
       | SLocal (id, { raw_ty = TBool }, e) -> BoolDef (id, e)
-      | SUnit { e = ECall (cid, es) } -> ExternCall (cid, es)
+      | SUnit { e = ECall (cid, es, _) } -> ExternCall (cid, es)
       | SIf (test1, s1, s2) -> begin
         match flatten_stmt s1, flatten_stmt s2 with
         | [{ s = SRet (Some ret) }], [] -> LocalRet (test1, ret)

--- a/src/lib/frontend/Printing.ml
+++ b/src/lib/frontend/Printing.ml
@@ -291,8 +291,11 @@ let rec e_to_string e =
       ^ string_of_int (List.length es)
       ^ ") to "
       ^ op_to_string op)
-  | ECall (cid, es) ->
-    Printf.sprintf "%s(%s)" (cid_to_string cid) (es_to_string es)
+  | ECall (cid, es, unordered) ->
+    if (unordered) then 
+      Printf.sprintf "%s(%s)" (cid_to_string cid) (es_to_string es)
+    else
+      Printf.sprintf "%s<unordered>(%s)" (cid_to_string cid) (es_to_string es)
   | EHash (size, es) ->
     Printf.sprintf "hash<<%s>>(%s)" (size_to_string size) (es_to_string es)
   | EFlood e -> Printf.sprintf "flood %s" (exp_to_string e)

--- a/src/lib/frontend/SlotAnalysis.ml
+++ b/src/lib/frontend/SlotAnalysis.ml
@@ -102,7 +102,7 @@ let extract_call e =
   let extract_var e =
     match e.e with
     | EVar cid -> Cid.to_id cid
-    | ECall (cid, []) when Cid.equal cid Payloads.payload_parse_cid ->
+    | ECall (cid, [], _) when Cid.equal cid Payloads.payload_parse_cid ->
       payload_parse_id
     | _ ->
       failwith
@@ -110,7 +110,7 @@ let extract_call e =
          call to Payload.parse "
   in
   match e.e with
-  | ECall (cid, es) -> cid, List.map extract_var es
+  | ECall (cid, es, _) -> cid, List.map extract_var es
   | _ -> failwith "slotAnalysis: expected a call in parser"
 ;;
 

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -154,7 +154,7 @@ and e =
       z * size option (* Differs from VInt since size may be polymorphic *)
   | EVar of cid
   | EOp of op * exp list
-  | ECall of cid * exp list
+  | ECall of cid * exp list * bool (* true if its an unordered call *)
   | EHash of size * exp list
   | EFlood of exp (* Generate a group of all ports but one *)
   | ESizeCast of size * size (* Cast a size to int *)
@@ -450,7 +450,7 @@ let var_sp cid span = exp_sp (EVar cid) span
 let eint z size = exp (EInt (z, size))
 let eint_sp z size span = exp_sp (EInt (z, size)) span
 let op_sp op args span = exp_sp (EOp (op, args)) span
-let call_sp cid args span = exp_sp (ECall (cid, args)) span
+let call_sp cid args span = exp_sp (ECall (cid, args, false)) span
 let hash_sp size args span = exp_sp (EHash (size, args)) span
 let proj_sp e l span = exp_sp (EProj (e, l)) span
 let record_sp lst span = exp_sp (ERecord lst) span

--- a/src/lib/frontend/Syntax.ml
+++ b/src/lib/frontend/Syntax.ml
@@ -451,6 +451,7 @@ let eint z size = exp (EInt (z, size))
 let eint_sp z size span = exp_sp (EInt (z, size)) span
 let op_sp op args span = exp_sp (EOp (op, args)) span
 let call_sp cid args span = exp_sp (ECall (cid, args, false)) span
+let ucall_sp cid args span = exp_sp (ECall (cid, args, true)) span
 let hash_sp size args span = exp_sp (EHash (size, args)) span
 let proj_sp e l span = exp_sp (EProj (e, l)) span
 let record_sp lst span = exp_sp (ERecord lst) span
@@ -538,6 +539,7 @@ let match_sp es bs span = statement_sp (SMatch (es, bs)) span
 let loop_sp e i k span = statement_sp (SLoop (e, i, k)) span
 let sexp_sp e span = statement_sp (SUnit e) span
 let scall_sp cid es span = sexp_sp (call_sp cid es span) span
+let sucall_sp cid es span = sexp_sp (ucall_sp cid es span) span
 
 let tblinstall_sp tbl entries span =
   statement_sp (STableInstall (tbl, entries)) span

--- a/src/lib/frontend/SyntaxGlobalDirectory.ml
+++ b/src/lib/frontend/SyntaxGlobalDirectory.ml
@@ -47,7 +47,7 @@ let exp_to_arrmeta id exp =
     name;
     compiled_cid = (Cid.id id);
     length = (match exp.e with
-      | ECall(_, len_exp::_) -> exp_to_int len_exp
+      | ECall(_, len_exp::_, _) -> exp_to_int len_exp
       | _ -> error "[dir_of_decls] wrong form");
     cell_size = [arrconstr_to_sz exp];}
   in
@@ -116,7 +116,7 @@ let core_exp_to_arrmeta id (exp:C.exp) =
   in
   let compiled_cid = (Cid.id id) in
   let length = (match exp.e with
-    | ECall(_, len_exp::_) -> C.exp_to_int len_exp
+    | ECall(_, len_exp::_, _) -> C.exp_to_int len_exp
     | _ -> error "[core_exp_to_arrmeta] array constructor has wrong form")
   in
   let cell_size = match exp.ety.raw_ty with

--- a/src/lib/frontend/Wellformed.ml
+++ b/src/lib/frontend/Wellformed.ml
@@ -241,7 +241,7 @@ let check_payloads ds =
 
       method! visit_exp () e =
         match e.e with
-        | ECall (cid, args) ->
+        | ECall (cid, args, _) ->
           List.iter (self#visit_exp ()) args;
           if in_parser && Cid.equal cid Payloads.payload_empty_cid
           then

--- a/src/lib/frontend/transformations/EStmtElimination.ml
+++ b/src/lib/frontend/transformations/EStmtElimination.ml
@@ -12,9 +12,9 @@ let rec inline_exp e =
   | EOp (op, es) ->
     let stmt, es' = inline_exps es in
     stmt, { e with e = EOp (op, es') }
-  | ECall (cid, es) ->
+  | ECall (cid, es, u) ->
     let stmt, es' = inline_exps es in
-    stmt, { e with e = ECall (cid, es') }
+    stmt, { e with e = ECall (cid, es', u) }
   | EHash (sz, es) ->
     let stmt, es' = inline_exps es in
     stmt, { e with e = EHash (sz, es') }

--- a/src/lib/frontend/transformations/FunctionInlining.ml
+++ b/src/lib/frontend/transformations/FunctionInlining.ml
@@ -137,7 +137,7 @@ let inliner =
 
     method! visit_exp env e =
       match e.e with
-      | ECall (cid, es) ->
+      | ECall (cid, es, u) ->
         let es = List.map (self#visit_exp env) es in
         (* case: cid is a function *)
         if CidMap.mem cid env.funcs
@@ -187,7 +187,7 @@ let inliner =
           inlined_exp)
         else
           (* Not user-defined function; we don't have to inline it *)
-          { e with e = ECall (cid, es) }
+          { e with e = ECall (cid, es, u) }
       | _ ->
         let res = super#visit_exp env e in
         res

--- a/src/lib/frontend/transformations/ModuleElimination.ml
+++ b/src/lib/frontend/transformations/ModuleElimination.ml
@@ -70,14 +70,14 @@ let subst =
         in
         STableInstall (etbl, entries)
 
-      method! visit_ECall env x args =
+      method! visit_ECall env x args u =
         let args = List.map (self#visit_exp env) args in
         let x =
           match CidMap.find_opt x env.vars with
           | None -> x
           | Some x' -> Id x'
         in
-        ECall (x, args)
+        ECall (x, args, u)
     end
   in
   v

--- a/src/lib/frontend/transformations/TableInlining.ml
+++ b/src/lib/frontend/transformations/TableInlining.ml
@@ -33,9 +33,9 @@ let rec eliminate_exp e =
   | EOp (op, es) ->
     let stmt, es' = eliminate_exps es in
     stmt, { e with e = EOp (op, es') }
-  | ECall (cid, es) ->
+  | ECall (cid, es, u) ->
     let stmt, es' = eliminate_exps es in
-    stmt, { e with e = ECall (cid, es') }
+    stmt, { e with e = ECall (cid, es', u) }
   | EHash (sz, es) ->
     let stmt, es' = eliminate_exps es in
     stmt, { e with e = EHash (sz, es') }

--- a/src/lib/frontend/transformations/TupleElimination.ml
+++ b/src/lib/frontend/transformations/TupleElimination.ml
@@ -242,9 +242,9 @@ let replacer =
     (* We replace tuple-type parameters to functions and events with
        one parameter for each tuple entry. So we need to adjust the
        arguments at the call site as well *)
-    method! visit_ECall env cid args =
+    method! visit_ECall env cid args unordered =
       let args = List.map (self#flatten env) args |> List.concat in
-      ECall (cid, args)
+      ECall (cid, args, unordered)
 
     (* Same as ECall *)
     method! visit_EHash env sz args =

--- a/src/lib/midend/CorePrinting.ml
+++ b/src/lib/midend/CorePrinting.ml
@@ -177,7 +177,10 @@ let rec e_to_string e =
       ^ string_of_int (List.length es)
       ^ ") to "
       ^ op_to_string op)
-  | ECall (cid, es) ->
+  | ECall (cid, es, unordered) ->
+    if (unordered) then 
+    Printf.sprintf "%s<unordered>(%s)" (cid_to_string cid) (es_to_string es)
+    else 
     Printf.sprintf "%s(%s)" (cid_to_string cid) (es_to_string es)
   | EHash (size, es) ->
     Printf.sprintf "hash<<%s>>(%s)" (size_to_string size) (es_to_string es)

--- a/src/lib/midend/CoreSyntax.ml
+++ b/src/lib/midend/CoreSyntax.ml
@@ -131,7 +131,7 @@ and e =
   | EVal of value
   | EVar of cid
   | EOp of op * exp list
-  | ECall of cid * exp list
+  | ECall of cid * exp list * bool
   | EHash of size * exp list
   | EFlood of exp
   | ETableCreate of tbl_def
@@ -356,7 +356,7 @@ let var_sp cid ety span = aexp (EVar cid) ety span
 let var cid ety = var_sp cid ety Span.default
 let op_sp op args ety span = aexp (EOp (op, args)) ety span
 let op op args ety = op_sp op args ety Span.default
-let call_sp cid args ety span = aexp (ECall (cid, args)) ety span
+let call_sp cid args ety span = aexp (ECall (cid, args, false)) ety span
 let call cid args ety = call_sp cid args ety Span.default
 let hash_sp size args ety span = aexp (EHash (size, args)) ety span
 let vint_exp i size = value_to_exp (vint i size)
@@ -483,8 +483,8 @@ let rec equiv_e e1 e2 =
   match e1, e2 with
   | EVal v1, EVal v2 -> equiv_value v1 v2
   | EVar cid1, EVar cid2 -> Cid.equal cid1 cid2
-  | ECall (cid1, es1), ECall (cid2, es2) ->
-    Cid.equal cid1 cid2 && equiv_list equiv_exp es1 es2
+  | ECall (cid1, es1, u1), ECall (cid2, es2, u2) ->
+    Cid.equal cid1 cid2 && equiv_list equiv_exp es1 es2 && (u1 = u2)
   | EHash (sz1, es1), EHash (sz2, es2) ->
     sz1 = sz2 && equiv_list equiv_exp es1 es2
   | EOp (op1, es1), EOp (op2, es2) -> op1 = op2 && equiv_list equiv_exp es1 es2

--- a/src/lib/midend/CoreSyntaxGlobalDirectory.ml
+++ b/src/lib/midend/CoreSyntaxGlobalDirectory.ml
@@ -15,7 +15,7 @@ let core_exp_to_arrmeta id (exp:C.exp) =
   in
   let compiled_cid = (Cid.id id) in
   let length = (match exp.e with
-    | ECall(_, len_exp::_) -> C.exp_to_int len_exp
+    | ECall(_, len_exp::_, _) -> C.exp_to_int len_exp
     | _ -> error "[core_exp_to_arrmeta] array constructor has wrong form")
   in
   let cell_size = match exp.ety.raw_ty with

--- a/src/lib/midend/interpreter/InterpCore.ml
+++ b/src/lib/midend/interpreter/InterpCore.ml
@@ -222,7 +222,7 @@ let rec interp_exp (nst : State.network_state) swid locals e : 'a InterpSyntax.i
   | EOp (op, es) ->
     let vs = interp_exps es in
     V (interp_op op vs)
-  | ECall (cid, es) ->
+  | ECall (cid, es, _) ->
     let vs = interp_exps es in
     (match lookup cid with
      | V _ ->
@@ -634,7 +634,7 @@ let _interp_dglobal (nst : State.network_state) swid id ty e =
   in
   let args =
     match e.e with
-    | ECall (_, args) -> args
+    | ECall (_, args, _) -> args
     | _ -> failwith "Bad constructor"
   in
   let new_p =
@@ -822,7 +822,7 @@ and interp_parser_step nst swid payload_id locals parser_step =
     )
     | PCall(exp) -> (
         match exp.e with 
-        | ECall(cid, args) -> (
+        | ECall(cid, args, _) -> (
           (* a call to another parser. *)
           (* construct ival arguments *)
           let args = 

--- a/src/lib/midend/interpreter/Pipeline.ml
+++ b/src/lib/midend/interpreter/Pipeline.ml
@@ -142,8 +142,8 @@ let get_obj_unconstrained stage t =
 
 let get_obj stage t =
   (* load the object from the pipe *)
-  if stage < 0 then failwith "Pipeline Error: Stage is negative";
-  if stage < !(t.current_stage)
+  if stage < 0 then failwith "Pipeline Error: Stage is negative";  
+  if (not (Cmdline.cfg.unordered) && stage < !(t.current_stage))
   then
     failwith
       "Pipeline Error: Attempted to access global out-of-order. The type \

--- a/src/lib/midend/interpreter/Pipeline.ml
+++ b/src/lib/midend/interpreter/Pipeline.ml
@@ -143,11 +143,13 @@ let get_obj_unconstrained stage t =
 let get_obj stage t =
   (* load the object from the pipe *)
   if stage < 0 then failwith "Pipeline Error: Stage is negative";  
-  if (not (Cmdline.cfg.unordered) && stage < !(t.current_stage))
+  (* we may want this to double check that accesses are ordered. 
+     (I don't think it matters though) *)
+  (* if (not (Cmdline.cfg.unordered) && stage < !(t.current_stage))
   then
     failwith
       "Pipeline Error: Attempted to access global out-of-order. The type \
-       system should have caught this, so notify the developer.";
+       system should have caught this, so notify the developer."; *)
   if stage >= Array.length t.objs
   then
     failwith

--- a/src/lib/midend/transformations/InterpHelpers.ml
+++ b/src/lib/midend/transformations/InterpHelpers.ml
@@ -133,7 +133,7 @@ let intwidth_of_exp (exp : exp) : int = intwidth_from_raw_ty exp.ety.raw_ty
 
 let args_of_exp exp =
   match exp.e with
-  | EOp (_, args) | ECall (_, args) | EHash (_, args) -> args
+  | EOp (_, args) | ECall (_, args, _) | EHash (_, args) -> args
   | _ -> []
 ;;
 
@@ -182,7 +182,7 @@ let is_atomic exp =
   (* ops are atomic if they are binary with all args immediates *)
   | EOp (_, args) -> CL.for_all is_immediate args && CL.length args <= 2
   (* calls are atomic if they have all immediate args *)
-  | EHash (_, args) | ECall (_, args) ->
+  | EHash (_, args) | ECall (_, args, _) ->
     CL.map is_immediate args |> CL.for_all identity
   (* a flood expression is atomic if its argument is an immediate *)
   | EFlood arg -> is_immediate arg
@@ -213,7 +213,7 @@ let replace_assign_rhs stmt exp =
 let replace_args exp new_args =
   match exp.e with
   | EOp (op, _) -> { exp with e = EOp (op, new_args) }
-  | ECall (id, _) -> { exp with e = ECall (id, new_args) }
+  | ECall (id, _, u) -> { exp with e = ECall (id, new_args, u) }
   | EHash (sz, _) -> { exp with e = EHash (sz, new_args) }
   | _ -> exp
 ;;
@@ -327,8 +327,8 @@ let rec replace_in_exp (exp : exp) (t : cid) (n : exp) : exp =
      | false -> exp)
   | { e = EOp (op, exps); _ } ->
     { exp with e = EOp (op, replace_in_exps exps t n) }
-  | { e = ECall (name, exps); _ } ->
-    { exp with e = ECall (name, replace_in_exps exps t n) }
+  | { e = ECall (name, exps, u); _ } ->
+    { exp with e = ECall (name, replace_in_exps exps t n, u) }
   | { e = EHash (sz, exps); _ } ->
     { exp with e = EHash (sz, replace_in_exps exps t n) }
   | _ -> exp

--- a/src/lib/midend/transformations/PartialInterpretation.ml
+++ b/src/lib/midend/transformations/PartialInterpretation.ml
@@ -168,8 +168,8 @@ let rec interp_exp env e =
     (match try_inline_variable env (Cid.to_id cid) with
      | Some e' -> { e with e = e' }
      | None -> e)
-  | ECall (cid, args) ->
-    { e with e = ECall (cid, List.map (interp_exp env) args) }
+  | ECall (cid, args, u) ->
+    { e with e = ECall (cid, List.map (interp_exp env) args, u) }
   | EHash (sz, args) ->
     { e with e = EHash (sz, List.map (interp_exp env) args) }
   | EFlood e' -> { e with e = EFlood (interp_exp env e') }
@@ -547,7 +547,7 @@ let remove_unused_variables stmt =
     let v =
       object
         inherit [_] s_iter
-        method! visit_ECall _ _ _ = acc := true
+        method! visit_ECall _ _ _ _ = acc := true
       end
     in
     v#visit_exp () e;

--- a/src/lib/midend/transformations/SyntaxToCore.ml
+++ b/src/lib/midend/transformations/SyntaxToCore.ml
@@ -116,7 +116,7 @@ let rec translate_exp (e : S.exp) : C.exp =
       C.EVal (C.vint (Z.to_int z) sz)
     | S.EVar cid -> C.EVar cid
     | S.EOp (op, es) -> C.EOp (translate_op op, List.map translate_exp es)
-    | S.ECall (cid, es) -> C.ECall (cid, List.map translate_exp es)
+    | S.ECall (cid, es, unordered) -> C.ECall (cid, List.map translate_exp es, unordered)
     | S.EHash (sz, es) -> C.EHash (translate_size sz, List.map translate_exp es)
     | S.EFlood e -> C.EFlood (translate_exp e)
     | ESizeCast _

--- a/src/lib/midend/transformations/eliminateInterpOps.ml
+++ b/src/lib/midend/transformations/eliminateInterpOps.ml
@@ -26,7 +26,7 @@ let eliminate_prog ds =
 
       method! visit_SUnit _ unit_exp =
         match unit_exp.e with
-        | ECall (cid, _) ->
+        | ECall (cid, _, _) ->
           if List.exists (Cid.equals cid) extern_cids
           then SNoop
           else super#visit_SUnit () unit_exp

--- a/src/lib/midend/transformations/precomputeArgs.ml
+++ b/src/lib/midend/transformations/precomputeArgs.ml
@@ -116,7 +116,7 @@ let precompute_args ds =
         | EHash (size, args) ->
           let new_args = CL.map self#precompute_arg args in
           { exp with e = EHash (size, new_args) }
-        | ECall (fcn_id, args) 
+        | ECall (fcn_id, args, u) 
             when (List.exists 
               (fun fcid -> Cid.equal_names fcn_id fcid)
               array_method_cids) -> (
@@ -133,16 +133,16 @@ let precompute_args ds =
                 else self#precompute_arg addr' 
               in
               let rest' = CL.map self#precompute_arg rest in
-              {exp with e = ECall (fcn_id, arr'::addr'::rest')}
+              {exp with e = ECall (fcn_id, arr'::addr'::rest', u)}
             | _ -> error "[precompute_args] array method call with < 3 args"
         )        
-        | ECall (fcn_id, args) ->
+        | ECall (fcn_id, args, u) ->
           (match CL.mem fcn_id exception_cids with
            | true -> exp (* skip event combinators *)
            | false ->
              (* pull out the argument if it is not an immediate *)
              let new_args = CL.map self#precompute_arg args in
-             { exp with e = ECall (fcn_id, new_args) })
+             { exp with e = ECall (fcn_id, new_args, u) })
         | _ -> exp
     end
   in


### PR DESCRIPTION
Added support for unordered operations over global-accessing functions. Call array builtins, and any user-function "f(...)" that take globals as arguments, with f<unordered>(...) to ignore effects in that function call. Any use of the unordered tag will fail well-formedness checks for a pipelined target (e.g., tofino) but is fine for non-pipelined targets (e.g., CPU-based).